### PR TITLE
GH-127 Remove Panics from Production Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3502,6 +3502,7 @@ dependencies = [
  "gluesql-core",
  "hex",
  "lru 0.16.3",
+ "parking_lot",
  "parquet",
  "pyo3",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rand = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3.3"
 thiserror = "2.0"
+parking_lot = "0.12"
 twox-hash = "2.0"
 serde_json = "1.0.117"
 arrow = "54.2.1"

--- a/src/agent/mem_lifecycle.rs
+++ b/src/agent/mem_lifecycle.rs
@@ -230,7 +230,7 @@ impl<T: MemoryStore> MemoryLifecycleManager<T> {
                     b.metadata
                         .confidence
                         .partial_cmp(&a.metadata.confidence)
-                        .unwrap()
+                        .unwrap_or(std::cmp::Ordering::Equal)
                 });
 
                 // Keep the most important ones

--- a/src/agent/mem_lifecycle.rs
+++ b/src/agent/mem_lifecycle.rs
@@ -226,10 +226,21 @@ impl<T: MemoryStore> MemoryLifecycleManager<T> {
         for ((namespace, tags), mut group_memories) in groups {
             if group_memories.len() > max_memories {
                 // Sort by importance/confidence
+                // Sort by confidence descending; treat NaN as lowest confidence
+                // so NaN-confidence memories are candidates for summarization first
                 group_memories.sort_by(|a, b| {
-                    b.metadata
-                        .confidence
-                        .partial_cmp(&a.metadata.confidence)
+                    let a_conf = if a.metadata.confidence.is_nan() {
+                        f64::NEG_INFINITY
+                    } else {
+                        a.metadata.confidence
+                    };
+                    let b_conf = if b.metadata.confidence.is_nan() {
+                        f64::NEG_INFINITY
+                    } else {
+                        b.metadata.confidence
+                    };
+                    b_conf
+                        .partial_cmp(&a_conf)
                         .unwrap_or(std::cmp::Ordering::Equal)
                 });
 

--- a/src/agent/persistence.rs
+++ b/src/agent/persistence.rs
@@ -165,13 +165,7 @@ impl InMemoryPersistence {
 
     /// Merge another branch (for in-memory, this is a no-op)
     pub async fn merge(&mut self, _branch: &str) -> Result<String, Box<dyn Error>> {
-        // Use a simple timestamp instead of chrono for in-memory implementation
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        Ok(format!("merge_result_{timestamp}"))
+        Ok(format!("merge_result_{}", uuid::Uuid::new_v4()))
     }
 
     /// Get history of commits

--- a/src/agent/persistence.rs
+++ b/src/agent/persistence.rs
@@ -169,7 +169,7 @@ impl InMemoryPersistence {
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs();
         Ok(format!("merge_result_{timestamp}"))
     }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -71,15 +71,15 @@ impl<const N: usize> ValueDigest<N> {
     }
 
     /// Creates a new `ValueDigest` from the raw hash bytes.
-    /// This method is useful for creating a `ValueDigest` from a known hash value.
     ///
-    /// # Arguments
+    /// This is intended for internal use where the data is known to have the correct
+    /// length (e.g., child hashes stored in tree node values). For external or
+    /// unvalidated input, prefer [`try_raw_hash`](Self::try_raw_hash) which returns
+    /// a `Result` instead of panicking.
     ///
-    /// * `data` - A slice of bytes representing the raw hash value.
+    /// # Panics
     ///
-    /// # Returns
-    ///
-    /// A `ValueDigest` instance containing the provided hash value.
+    /// Panics if `data.len() != N`.
     pub fn raw_hash(data: &[u8]) -> Self {
         ValueDigest(<[u8; N]>::try_from(data).expect("data length must match digest size N"))
     }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -12,6 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use crate::errors::ProllyTreeError;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -80,7 +81,22 @@ impl<const N: usize> ValueDigest<N> {
     ///
     /// A `ValueDigest` instance containing the provided hash value.
     pub fn raw_hash(data: &[u8]) -> Self {
-        ValueDigest(<[u8; N]>::try_from(data).unwrap())
+        ValueDigest(<[u8; N]>::try_from(data).expect("data length must match digest size N"))
+    }
+
+    /// Creates a new `ValueDigest` from the raw hash bytes, returning an error if the
+    /// data length does not match the expected digest size `N`.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - A slice of bytes representing the raw hash value.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a `ValueDigest` instance or a `ProllyTreeError` if the length is wrong.
+    pub fn try_raw_hash(data: &[u8]) -> Result<Self, ProllyTreeError> {
+        let arr = <[u8; N]>::try_from(data).map_err(|_| ProllyTreeError::InvalidDigestLength)?;
+        Ok(ValueDigest(arr))
     }
 
     /// Returns a reference to the underlying byte array of the hash.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -129,111 +129,110 @@ impl<const N: usize> ProllyNode<N> {
     ) -> Result<RecordBatch, ProllyTreeError> {
         let schema = schema.as_ref().ok_or(ProllyTreeError::SchemaNotFound)?;
 
-        if let Some(object) = &schema.schema.object {
-            let fields: Vec<Field> = object
-                .properties
-                .iter()
-                .map(|(name, schema)| {
-                    let data_type = match &schema {
-                        schemars::schema::Schema::Object(SchemaObject {
-                            instance_type: Some(instance_type),
-                            ..
-                        }) => match instance_type {
-                            schemars::schema::SingleOrVec::Single(single_type) => {
-                                match **single_type {
-                                    schemars::schema::InstanceType::String => DataType::Utf8,
-                                    schemars::schema::InstanceType::Integer => DataType::Int32,
-                                    schemars::schema::InstanceType::Boolean => DataType::Boolean,
-                                    schemars::schema::InstanceType::Number => DataType::Float64,
-                                    _ => panic!("Unsupported data type in schema"),
-                                }
-                            }
-                            schemars::schema::SingleOrVec::Vec(vec_type) => {
-                                match vec_type.as_slice() {
-                                    [schemars::schema::InstanceType::String] => DataType::Utf8,
-                                    [schemars::schema::InstanceType::Integer] => DataType::Int32,
-                                    [schemars::schema::InstanceType::Boolean] => DataType::Boolean,
-                                    [schemars::schema::InstanceType::Number] => DataType::Float64,
-                                    _ => panic!("Unsupported data type in schema"),
-                                }
-                            }
+        let object = schema
+            .schema
+            .object
+            .as_ref()
+            .ok_or(ProllyTreeError::SchemaNotFound)?;
+
+        let fields: Result<Vec<Field>, ProllyTreeError> = object
+            .properties
+            .iter()
+            .map(|(name, schema)| {
+                let data_type = match &schema {
+                    schemars::schema::Schema::Object(SchemaObject {
+                        instance_type: Some(instance_type),
+                        ..
+                    }) => match instance_type {
+                        schemars::schema::SingleOrVec::Single(single_type) => match **single_type {
+                            schemars::schema::InstanceType::String => DataType::Utf8,
+                            schemars::schema::InstanceType::Integer => DataType::Int32,
+                            schemars::schema::InstanceType::Boolean => DataType::Boolean,
+                            schemars::schema::InstanceType::Number => DataType::Float64,
+                            _ => return Err(ProllyTreeError::UnsupportedValueType),
                         },
-                        _ => panic!("Unsupported schema format"),
-                    };
-                    Field::new(name, data_type, false)
-                })
-                .collect();
+                        schemars::schema::SingleOrVec::Vec(vec_type) => match vec_type.as_slice() {
+                            [schemars::schema::InstanceType::String] => DataType::Utf8,
+                            [schemars::schema::InstanceType::Integer] => DataType::Int32,
+                            [schemars::schema::InstanceType::Boolean] => DataType::Boolean,
+                            [schemars::schema::InstanceType::Number] => DataType::Float64,
+                            _ => return Err(ProllyTreeError::UnsupportedValueType),
+                        },
+                    },
+                    _ => return Err(ProllyTreeError::UnsupportedValueType),
+                };
+                Ok(Field::new(name, data_type, false))
+            })
+            .collect();
+        let fields = fields?;
 
-            let values: Result<Vec<serde_json::Value>, _> =
-                data.iter().map(|v| serde_json::from_slice(v)).collect();
-            let values = values?;
+        let values: Result<Vec<serde_json::Value>, _> =
+            data.iter().map(|v| serde_json::from_slice(v)).collect();
+        let values = values?;
 
-            let arrays: Result<Vec<ArrayRef>, _> = fields
-                .iter()
-                .map(|field| -> Result<ArrayRef, ProllyTreeError> {
-                    match field.data_type() {
-                        DataType::Utf8 => {
-                            let string_values: Result<Vec<&str>, _> = values
-                                .iter()
-                                .map(|value| {
-                                    value
-                                        .get(field.name())
-                                        .and_then(|v| v.as_str())
-                                        .ok_or(ProllyTreeError::InvalidJsonValue)
-                                })
-                                .collect();
-                            Ok(Arc::new(StringArray::from(string_values?)) as ArrayRef)
-                        }
-                        DataType::Int32 => {
-                            let int_values: Result<Vec<i32>, _> = values
-                                .iter()
-                                .map(|value| {
-                                    value
-                                        .get(field.name())
-                                        .and_then(|v| v.as_i64())
-                                        .map(|v| v as i32)
-                                        .ok_or(ProllyTreeError::InvalidJsonValue)
-                                })
-                                .collect();
-                            Ok(Arc::new(Int32Array::from(int_values?)) as ArrayRef)
-                        }
-                        DataType::Boolean => {
-                            let bool_values: Result<Vec<bool>, _> = values
-                                .iter()
-                                .map(|value| {
-                                    value
-                                        .get(field.name())
-                                        .and_then(|v| v.as_bool())
-                                        .ok_or(ProllyTreeError::InvalidJsonValue)
-                                })
-                                .collect();
-                            Ok(Arc::new(BooleanArray::from(bool_values?)) as ArrayRef)
-                        }
-                        DataType::Float64 => {
-                            let float_values: Result<Vec<f64>, _> = values
-                                .iter()
-                                .map(|value| {
-                                    value
-                                        .get(field.name())
-                                        .and_then(|v| v.as_f64())
-                                        .ok_or(ProllyTreeError::InvalidJsonValue)
-                                })
-                                .collect();
-                            Ok(Arc::new(Float64Array::from(float_values?)) as ArrayRef)
-                        }
-                        _ => panic!("Unsupported data type"),
+        let arrays: Result<Vec<ArrayRef>, _> = fields
+            .iter()
+            .map(|field| -> Result<ArrayRef, ProllyTreeError> {
+                match field.data_type() {
+                    DataType::Utf8 => {
+                        let string_values: Result<Vec<&str>, _> = values
+                            .iter()
+                            .map(|value| {
+                                value
+                                    .get(field.name())
+                                    .and_then(|v| v.as_str())
+                                    .ok_or(ProllyTreeError::InvalidJsonValue)
+                            })
+                            .collect();
+                        Ok(Arc::new(StringArray::from(string_values?)) as ArrayRef)
                     }
-                })
-                .collect();
+                    DataType::Int32 => {
+                        let int_values: Result<Vec<i32>, _> = values
+                            .iter()
+                            .map(|value| {
+                                value
+                                    .get(field.name())
+                                    .and_then(|v| v.as_i64())
+                                    .map(|v| v as i32)
+                                    .ok_or(ProllyTreeError::InvalidJsonValue)
+                            })
+                            .collect();
+                        Ok(Arc::new(Int32Array::from(int_values?)) as ArrayRef)
+                    }
+                    DataType::Boolean => {
+                        let bool_values: Result<Vec<bool>, _> = values
+                            .iter()
+                            .map(|value| {
+                                value
+                                    .get(field.name())
+                                    .and_then(|v| v.as_bool())
+                                    .ok_or(ProllyTreeError::InvalidJsonValue)
+                            })
+                            .collect();
+                        Ok(Arc::new(BooleanArray::from(bool_values?)) as ArrayRef)
+                    }
+                    DataType::Float64 => {
+                        let float_values: Result<Vec<f64>, _> = values
+                            .iter()
+                            .map(|value| {
+                                value
+                                    .get(field.name())
+                                    .and_then(|v| v.as_f64())
+                                    .ok_or(ProllyTreeError::InvalidJsonValue)
+                            })
+                            .collect();
+                        Ok(Arc::new(Float64Array::from(float_values?)) as ArrayRef)
+                    }
+                    _ => Err(ProllyTreeError::UnsupportedValueType),
+                }
+            })
+            .collect();
 
-            // Create a RecordBatch to return
-            Ok(RecordBatch::try_new(
-                Arc::new(Schema::new(fields)),
-                arrays?,
-            )?)
-        } else {
-            panic!("Unsupported schema")
-        }
+        // Create a RecordBatch to return
+        Ok(RecordBatch::try_new(
+            Arc::new(Schema::new(fields)),
+            arrays?,
+        )?)
     }
 
     pub fn encode_all_pairs(&mut self) -> Result<(), ProllyTreeError> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,4 +48,7 @@ pub enum ProllyTreeError {
 
     #[error("Invalid JSON value")]
     InvalidJsonValue,
+
+    #[error("Invalid digest length")]
+    InvalidDigestLength,
 }

--- a/src/git/storage.rs
+++ b/src/git/storage.rs
@@ -20,7 +20,10 @@ use gix::prelude::*;
 use lru::LruCache;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex};
+
+const DEFAULT_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).unwrap();
+use parking_lot::Mutex;
+use std::sync::Arc;
 
 /// Git-backed storage for ProllyTree nodes
 ///
@@ -42,7 +45,7 @@ impl<const N: usize> Clone for GitNodeStorage<N> {
     fn clone(&self) -> Self {
         let cloned = Self {
             _repository: self._repository.clone(),
-            cache: Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap())),
+            cache: Mutex::new(LruCache::new(DEFAULT_CACHE_SIZE)),
             configs: Mutex::new(HashMap::new()),
             hash_to_object_id: Mutex::new(HashMap::new()),
             dataset_dir: self.dataset_dir.clone(),
@@ -63,7 +66,7 @@ impl<const N: usize> GitNodeStorage<N> {
 
     /// Get a copy of the current hash mappings
     pub fn get_hash_mappings(&self) -> HashMap<ValueDigest<N>, gix::ObjectId> {
-        self.hash_to_object_id.lock().unwrap().clone()
+        self.hash_to_object_id.lock().clone()
     }
 
     /// Create a new GitNodeStorage instance
@@ -71,7 +74,7 @@ impl<const N: usize> GitNodeStorage<N> {
         repository: gix::Repository,
         dataset_dir: std::path::PathBuf,
     ) -> Result<Self, GitKvError> {
-        let cache_size = NonZeroUsize::new(1000).unwrap(); // Default cache size
+        let cache_size = DEFAULT_CACHE_SIZE; // Default cache size
 
         let storage = GitNodeStorage {
             _repository: Arc::new(Mutex::new(repository)),
@@ -93,7 +96,7 @@ impl<const N: usize> GitNodeStorage<N> {
         dataset_dir: std::path::PathBuf,
         cache_size: usize,
     ) -> Result<Self, GitKvError> {
-        let cache_size = NonZeroUsize::new(cache_size).unwrap_or(NonZeroUsize::new(1000).unwrap());
+        let cache_size = NonZeroUsize::new(cache_size).unwrap_or(DEFAULT_CACHE_SIZE);
 
         let storage = GitNodeStorage {
             _repository: Arc::new(Mutex::new(repository)),
@@ -115,7 +118,7 @@ impl<const N: usize> GitNodeStorage<N> {
         dataset_dir: std::path::PathBuf,
         hash_mappings: HashMap<ValueDigest<N>, gix::ObjectId>,
     ) -> Result<Self, GitKvError> {
-        let cache_size = NonZeroUsize::new(1000).unwrap(); // Default cache size
+        let cache_size = DEFAULT_CACHE_SIZE; // Default cache size
 
         let storage = GitNodeStorage {
             _repository: Arc::new(Mutex::new(repository)),
@@ -133,7 +136,7 @@ impl<const N: usize> GitNodeStorage<N> {
         let serialized = bincode::serialize(node)?;
 
         // Write the serialized node as a Git blob
-        let repo = self._repository.lock().unwrap();
+        let repo = self._repository.lock();
         let blob = gix::objs::Blob { data: serialized };
         let blob_id = repo
             .objects
@@ -145,7 +148,7 @@ impl<const N: usize> GitNodeStorage<N> {
 
     /// Load a node from a Git blob
     fn load_node_from_blob(&self, blob_id: &gix::ObjectId) -> Result<ProllyNode<N>, GitKvError> {
-        let repo = self._repository.lock().unwrap();
+        let repo = self._repository.lock();
 
         // Find the blob object
         let mut buffer = Vec::new();
@@ -164,12 +167,12 @@ impl<const N: usize> GitNodeStorage<N> {
 impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
     fn get_node_by_hash(&self, hash: &ValueDigest<N>) -> Option<ProllyNode<N>> {
         // First check cache
-        if let Some(node) = self.cache.lock().unwrap().peek(hash) {
+        if let Some(node) = self.cache.lock().peek(hash) {
             return Some(node.clone());
         }
 
         // Check if we have a mapping for this hash
-        let object_id = self.hash_to_object_id.lock().unwrap().get(hash).cloned()?;
+        let object_id = self.hash_to_object_id.lock().get(hash).cloned()?;
 
         // Load from Git blob
         self.load_node_from_blob(&object_id).ok()
@@ -177,19 +180,16 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
 
     fn insert_node(&mut self, hash: ValueDigest<N>, node: ProllyNode<N>) -> Option<()> {
         // Check if this node already exists in our mappings
-        let already_exists = self.hash_to_object_id.lock().unwrap().contains_key(&hash);
+        let already_exists = self.hash_to_object_id.lock().contains_key(&hash);
 
         // Store in cache
-        self.cache.lock().unwrap().put(hash.clone(), node.clone());
+        self.cache.lock().put(hash.clone(), node.clone());
 
         // Store as Git blob
         match self.store_node_as_blob(&node) {
             Ok(blob_id) => {
                 // Store the mapping between ProllyTree hash and Git object ID
-                self.hash_to_object_id
-                    .lock()
-                    .unwrap()
-                    .insert(hash.clone(), blob_id);
+                self.hash_to_object_id.lock().insert(hash.clone(), blob_id);
 
                 // Only persist the mapping to filesystem if it's a new node
                 // This prevents duplicate entries when reloading trees for read-only operations
@@ -205,10 +205,10 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
 
     fn delete_node(&mut self, hash: &ValueDigest<N>) -> Option<()> {
         // Remove from cache
-        self.cache.lock().unwrap().pop(hash);
+        self.cache.lock().pop(hash);
 
         // Remove from mapping
-        self.hash_to_object_id.lock().unwrap().remove(hash);
+        self.hash_to_object_id.lock().remove(hash);
 
         // Note: Git doesn't really "delete" objects - they become unreachable
         // and will be garbage collected eventually. For now, we'll just consider
@@ -218,7 +218,7 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
 
     fn save_config(&self, key: &str, config: &[u8]) {
         // Store config in memory
-        let mut configs = self.configs.lock().unwrap();
+        let mut configs = self.configs.lock();
         configs.insert(key.to_string(), config.to_vec());
 
         // Also persist to filesystem for durability in the dataset directory
@@ -228,7 +228,7 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
 
     fn get_config(&self, key: &str) -> Option<Vec<u8>> {
         // First try to get from memory
-        if let Some(config) = self.configs.lock().unwrap().get(key).cloned() {
+        if let Some(config) = self.configs.lock().get(key).cloned() {
             return Some(config);
         }
 
@@ -236,10 +236,7 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
         let config_path = self.dataset_dir.join(format!("prolly_config_{key}"));
         if let Ok(config) = std::fs::read(config_path) {
             // Cache in memory for future use
-            self.configs
-                .lock()
-                .unwrap()
-                .insert(key.to_string(), config.clone());
+            self.configs.lock().insert(key.to_string(), config.clone());
             return Some(config);
         }
 
@@ -274,7 +271,7 @@ impl<const N: usize> GitNodeStorage<N> {
         let mapping_path = self.dataset_dir.join("prolly_hash_mappings");
 
         if let Ok(mappings) = std::fs::read_to_string(mapping_path) {
-            let mut hash_map = self.hash_to_object_id.lock().unwrap();
+            let mut hash_map = self.hash_to_object_id.lock();
 
             for line in mappings.lines() {
                 if let Some((hash_hex, object_hex)) = line.split_once(':') {
@@ -374,7 +371,7 @@ mod tests {
 
         // Insert and verify it's cached
         storage.insert_node(hash1.clone(), node1.clone());
-        assert!(storage.cache.lock().unwrap().contains(&hash1));
+        assert!(storage.cache.lock().contains(&hash1));
 
         // Get from cache
         let cached = storage.get_node_by_hash(&hash1);

--- a/src/git/versioned_store.rs
+++ b/src/git/versioned_store.rs
@@ -20,9 +20,10 @@ use crate::git::types::*;
 use crate::storage::{FileNodeStorage, InMemoryNodeStorage, NodeStorage};
 use crate::tree::{ProllyTree, Tree};
 use gix::prelude::*;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// Trait for accessing historical state from version control
 pub trait HistoricalAccess<const N: usize> {
@@ -3254,87 +3255,67 @@ where
 {
     /// Insert a key-value pair (stages the change)
     pub fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), GitKvError> {
-        let mut store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let mut store = self.inner.lock();
         store.insert(key, value)
     }
 
     /// Update an existing key-value pair (stages the change)
     pub fn update(&self, key: Vec<u8>, value: Vec<u8>) -> Result<bool, GitKvError> {
-        let mut store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let mut store = self.inner.lock();
         store.update(key, value)
     }
 
     /// Delete a key-value pair (stages the change)
     pub fn delete(&self, key: &[u8]) -> Result<bool, GitKvError> {
-        let mut store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let mut store = self.inner.lock();
         store.delete(key)
     }
 
     /// Get a value by key (checks staging area first, then committed data)
     pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        let store = self.inner.lock().ok()?;
+        let store = self.inner.lock();
         store.get(key)
     }
 
     /// List all keys (includes staged changes)
     pub fn list_keys(&self) -> Result<Vec<Vec<u8>>, GitKvError> {
-        let store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let store = self.inner.lock();
         Ok(store.list_keys())
     }
 
     /// Show current staging area status
     pub fn status(&self) -> Result<Vec<(Vec<u8>, String)>, GitKvError> {
-        let store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let store = self.inner.lock();
         Ok(store.status())
     }
 
     /// Commit staged changes
     pub fn commit(&self, message: &str) -> Result<gix::ObjectId, GitKvError> {
-        let mut store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let mut store = self.inner.lock();
         store.commit(message)
     }
 
     /// Create a new branch
     pub fn create_branch(&self, name: &str) -> Result<(), GitKvError> {
-        let mut store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let mut store = self.inner.lock();
         store.create_branch(name)
     }
 
     /// Get commit history
     pub fn log(&self) -> Result<Vec<CommitInfo>, GitKvError> {
-        let store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let store = self.inner.lock();
         store.log()
     }
 
     /// Get current branch name
     pub fn current_branch(&self) -> Result<String, GitKvError> {
-        let store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let store = self.inner.lock();
         Ok(store.current_branch().to_string())
     }
 
     /// Get the underlying git repository reference (creates a clone)
     pub fn git_repo(&self) -> Result<gix::Repository, GitKvError> {
-        let store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let store = self.inner.lock();
         Ok(store.git_repo().clone())
     }
 }
@@ -3342,9 +3323,7 @@ where
 impl<const N: usize> ThreadSafeGitVersionedKvStore<N> {
     /// Switch to a different branch - Git-specific implementation
     pub fn checkout(&self, name: &str) -> Result<(), GitKvError> {
-        let mut store = self.inner.lock().map_err(|_| {
-            GitKvError::GitObjectError("Failed to acquire lock on store".to_string())
-        })?;
+        let mut store = self.inner.lock();
         store.checkout(name)
     }
 }

--- a/src/git/versioned_store.rs
+++ b/src/git/versioned_store.rs
@@ -82,8 +82,14 @@ pub type RocksDBVersionedKvStore<const N: usize> = VersionedKvStore<N, RocksDBNo
 /// Thread-safe wrapper for VersionedKvStore
 ///
 /// This wrapper provides thread-safe access to the underlying VersionedKvStore by using
-/// Arc<Mutex<>> internally. All operations are synchronized, making it safe to use
+/// `Arc<Mutex<>>` internally. All operations are synchronized, making it safe to use
 /// across multiple threads.
+///
+/// Uses `parking_lot::Mutex` which does not support lock poisoning. If a thread panics
+/// while holding the lock, subsequent lock acquisitions will succeed and the data
+/// remains accessible. This is intentional: the previous `std::sync::Mutex` approach
+/// also panicked (via `.unwrap()`) on poisoned locks, so callers had no recovery path
+/// either way. With `parking_lot`, the application at least has a chance to continue.
 pub struct ThreadSafeVersionedKvStore<const N: usize, S: NodeStorage<N>> {
     inner: Arc<Mutex<VersionedKvStore<N, S>>>,
 }

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -25,10 +25,11 @@ limitations under the License.
 //! - Shared object database with the main repository
 
 use crate::git::types::*;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// Represents a worktree for a VersionedKvStore
@@ -276,7 +277,9 @@ impl WorktreeManager {
 
         if head_content.starts_with("ref: refs/heads/") {
             // HEAD points to a branch, read that branch's commit
-            let branch_name = head_content.strip_prefix("ref: refs/heads/").unwrap();
+            let branch_name = head_content
+                .strip_prefix("ref: refs/heads/")
+                .unwrap_or(head_content);
             let branch_ref = self.git_dir.join("refs").join("heads").join(branch_name);
 
             if branch_ref.exists() {
@@ -920,19 +923,19 @@ impl<const N: usize> WorktreeVersionedKvStore<N> {
 
     /// Check if this worktree is locked
     pub fn is_locked(&self) -> bool {
-        let manager = self.manager.lock().unwrap();
+        let manager = self.manager.lock();
         manager.is_locked(&self.worktree_info.id)
     }
 
     /// Lock this worktree
     pub fn lock(&self, reason: &str) -> Result<(), GitKvError> {
-        let mut manager = self.manager.lock().unwrap();
+        let mut manager = self.manager.lock();
         manager.lock_worktree(&self.worktree_info.id, reason)
     }
 
     /// Unlock this worktree
     pub fn unlock(&self) -> Result<(), GitKvError> {
-        let mut manager = self.manager.lock().unwrap();
+        let mut manager = self.manager.lock();
         manager.unlock_worktree(&self.worktree_info.id)
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -418,11 +418,7 @@ impl<const N: usize> Balanced<N> for ProllyNode<N> {
         storage: &S,
         path_hashes: &[ValueDigest<N>],
     ) -> Option<Vec<u8>> {
-        // if let Some(parent_hash) = parent_hash {
-        if !path_hashes.is_empty() {
-            // Retrieve the parent node using the parent hash
-            let last_parent_hash = path_hashes.last().unwrap();
-
+        if let Some(last_parent_hash) = path_hashes.last() {
             // Retrieve the parent node using the parent hash
             if let Some(parent_node) = storage.get_node_by_hash(last_parent_hash) {
                 if self.keys.is_empty() {

--- a/src/python.rs
+++ b/src/python.rs
@@ -12,12 +12,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use parking_lot::Mutex;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyBytesMethods, PyDict, PyList};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::{
     agent::{AgentMemorySystem, MemoryType},
@@ -163,7 +164,7 @@ impl PyProllyTree {
         let value_vec = value.as_bytes().to_vec();
 
         py.allow_threads(|| {
-            let mut tree_wrapper = self.tree.lock().unwrap();
+            let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.insert(key_vec, value_vec);
                 Ok(())
@@ -176,7 +177,7 @@ impl PyProllyTree {
         let values: Vec<Vec<u8>> = items.iter().map(|(_, v)| v.clone()).collect();
 
         py.allow_threads(|| {
-            let mut tree_wrapper = self.tree.lock().unwrap();
+            let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.insert_batch(&keys, &values);
                 Ok(())
@@ -188,7 +189,7 @@ impl PyProllyTree {
         let key_vec = key.as_bytes().to_vec();
 
         let result = py.allow_threads(|| {
-            let tree_wrapper = self.tree.lock().unwrap();
+            let tree_wrapper = self.tree.lock();
             with_tree!(tree_wrapper, tree, { tree.find(&key_vec) })
         });
 
@@ -219,7 +220,7 @@ impl PyProllyTree {
         let value_vec = value.as_bytes().to_vec();
 
         py.allow_threads(|| {
-            let mut tree_wrapper = self.tree.lock().unwrap();
+            let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.update(key_vec, value_vec);
                 Ok(())
@@ -231,7 +232,7 @@ impl PyProllyTree {
         let key_vec = key.as_bytes().to_vec();
 
         py.allow_threads(|| {
-            let mut tree_wrapper = self.tree.lock().unwrap();
+            let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.delete(&key_vec);
                 Ok(())
@@ -243,7 +244,7 @@ impl PyProllyTree {
         let key_vecs: Vec<Vec<u8>> = keys;
 
         py.allow_threads(|| {
-            let mut tree_wrapper = self.tree.lock().unwrap();
+            let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.delete_batch(&key_vecs);
                 Ok(())
@@ -252,17 +253,17 @@ impl PyProllyTree {
     }
 
     fn size(&self) -> PyResult<usize> {
-        let tree_wrapper = self.tree.lock().unwrap();
+        let tree_wrapper = self.tree.lock();
         Ok(with_tree!(tree_wrapper, tree, tree.size()))
     }
 
     fn depth(&self) -> PyResult<usize> {
-        let tree_wrapper = self.tree.lock().unwrap();
+        let tree_wrapper = self.tree.lock();
         Ok(with_tree!(tree_wrapper, tree, tree.depth()))
     }
 
     fn get_root_hash(&self, py: Python) -> PyResult<Py<PyBytes>> {
-        let tree_wrapper = self.tree.lock().unwrap();
+        let tree_wrapper = self.tree.lock();
         let hash_opt = with_tree!(tree_wrapper, tree, tree.get_root_hash());
         match hash_opt {
             Some(hash) => Ok(PyBytes::new_bound(py, hash.as_ref()).into()),
@@ -271,7 +272,7 @@ impl PyProllyTree {
     }
 
     fn stats(&self) -> PyResult<HashMap<String, usize>> {
-        let tree_wrapper = self.tree.lock().unwrap();
+        let tree_wrapper = self.tree.lock();
         let stats = with_tree!(tree_wrapper, tree, tree.stats());
         let mut map = HashMap::new();
         map.insert("num_nodes".to_string(), stats.num_nodes);
@@ -289,7 +290,7 @@ impl PyProllyTree {
         let key_vec = key.as_bytes().to_vec();
 
         let proof_bytes = py.allow_threads(|| {
-            let tree_wrapper = self.tree.lock().unwrap();
+            let tree_wrapper = self.tree.lock();
             let proof = with_tree!(tree_wrapper, tree, tree.generate_proof(&key_vec));
 
             bincode::serialize(&proof)
@@ -316,7 +317,7 @@ impl PyProllyTree {
                 PyValueError::new_err(format!("Proof deserialization failed: {}", e))
             })?;
 
-            let tree_wrapper = self.tree.lock().unwrap();
+            let tree_wrapper = self.tree.lock();
             Ok(with_tree!(
                 tree_wrapper,
                 tree,
@@ -353,13 +354,13 @@ impl PyProllyTree {
     }
 
     fn traverse(&self) -> PyResult<String> {
-        let tree_wrapper = self.tree.lock().unwrap();
+        let tree_wrapper = self.tree.lock();
         Ok(with_tree!(tree_wrapper, tree, tree.traverse()))
     }
 
     fn save_config(&self, py: Python) -> PyResult<()> {
         py.allow_threads(|| {
-            let tree_wrapper = self.tree.lock().unwrap();
+            let tree_wrapper = self.tree.lock();
             with_tree!(tree_wrapper, tree, {
                 let _ = tree.save_config();
                 Ok(())
@@ -453,7 +454,7 @@ impl PyAgentMemorySystem {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let mut memory_system = self.inner.lock().unwrap();
+            let mut memory_system = self.inner.lock();
 
             // Convert HashMap<String, String> to HashMap<String, serde_json::Value>
             let metadata_values = metadata.map(|m| {
@@ -485,7 +486,7 @@ impl PyAgentMemorySystem {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let memory_system = self.inner.lock().unwrap();
+            let memory_system = self.inner.lock();
 
             runtime.block_on(async {
                 let history = memory_system
@@ -527,7 +528,7 @@ impl PyAgentMemorySystem {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let mut memory_system = self.inner.lock().unwrap();
+            let mut memory_system = self.inner.lock();
 
             let facts_value: serde_json::Value = serde_json::from_str(&facts)
                 .map_err(|e| PyValueError::new_err(format!("Invalid JSON: {}", e)))?;
@@ -552,7 +553,7 @@ impl PyAgentMemorySystem {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let memory_system = self.inner.lock().unwrap();
+            let memory_system = self.inner.lock();
 
             runtime.block_on(async {
                 let facts = memory_system
@@ -600,7 +601,7 @@ impl PyAgentMemorySystem {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let mut memory_system = self.inner.lock().unwrap();
+            let mut memory_system = self.inner.lock();
 
             let steps_values: Result<Vec<serde_json::Value>, _> =
                 steps.iter().map(|s| serde_json::from_str(s)).collect();
@@ -638,7 +639,7 @@ impl PyAgentMemorySystem {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let memory_system = self.inner.lock().unwrap();
+            let memory_system = self.inner.lock();
 
             runtime.block_on(async {
                 let procedures = memory_system
@@ -674,7 +675,7 @@ impl PyAgentMemorySystem {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let mut memory_system = self.inner.lock().unwrap();
+            let mut memory_system = self.inner.lock();
 
             runtime.block_on(async {
                 memory_system.checkpoint(&message).await.map_err(|e| {
@@ -689,7 +690,7 @@ impl PyAgentMemorySystem {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let mut memory_system = self.inner.lock().unwrap();
+            let mut memory_system = self.inner.lock();
 
             runtime.block_on(async {
                 let report = memory_system
@@ -1038,7 +1039,7 @@ impl PyVersionedKvStore {
         let key_vec = key.as_bytes().to_vec();
         let value_vec = value.as_bytes().to_vec();
 
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
         with_versioned_store_mut!(guard, store, {
             store
                 .insert(key_vec, value_vec)
@@ -1050,7 +1051,7 @@ impl PyVersionedKvStore {
     fn get(&self, py: Python, key: &Bound<'_, PyBytes>) -> PyResult<Option<Py<PyBytes>>> {
         let key_vec = key.as_bytes().to_vec();
 
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
         with_versioned_store!(guard, store, {
             match store.get(&key_vec) {
                 Some(value) => Ok(Some(PyBytes::new_bound(py, &value).into())),
@@ -1063,7 +1064,7 @@ impl PyVersionedKvStore {
         let key_vec = key.as_bytes().to_vec();
         let value_vec = value.as_bytes().to_vec();
 
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
         with_versioned_store_mut!(guard, store, {
             store
                 .update(key_vec, value_vec)
@@ -1074,7 +1075,7 @@ impl PyVersionedKvStore {
     fn delete(&self, key: &Bound<'_, PyBytes>) -> PyResult<bool> {
         let key_vec = key.as_bytes().to_vec();
 
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
         with_versioned_store_mut!(guard, store, {
             store
                 .delete(&key_vec)
@@ -1083,7 +1084,7 @@ impl PyVersionedKvStore {
     }
 
     fn list_keys(&self, py: Python) -> PyResult<Vec<Py<PyBytes>>> {
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
         with_versioned_store!(guard, store, {
             let keys = store.list_keys();
 
@@ -1107,7 +1108,7 @@ impl PyVersionedKvStore {
     }
 
     fn status(&self, py: Python) -> PyResult<Vec<(Py<PyBytes>, String)>> {
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
         with_versioned_store!(guard, store, {
             let status = store.status();
 
@@ -1121,7 +1122,7 @@ impl PyVersionedKvStore {
     }
 
     fn commit(&self, message: String) -> PyResult<String> {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
         with_versioned_store_mut!(guard, store, {
             let commit_id = store
                 .commit(&message)
@@ -1132,7 +1133,7 @@ impl PyVersionedKvStore {
     }
 
     fn branch(&self, name: String) -> PyResult<()> {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
         with_versioned_store_mut!(guard, store, {
             store
                 .branch(&name)
@@ -1143,7 +1144,7 @@ impl PyVersionedKvStore {
     }
 
     fn create_branch(&self, name: String) -> PyResult<()> {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
         with_versioned_store_mut!(guard, store, {
             store.create_branch(&name).map_err(|e| {
                 PyValueError::new_err(format!("Failed to create and switch branch: {}", e))
@@ -1154,7 +1155,7 @@ impl PyVersionedKvStore {
     }
 
     fn checkout(&self, branch_or_commit: String) -> PyResult<()> {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
         // All backends support checkout because they all use git for version control
         with_versioned_store_mut!(guard, store, {
             store
@@ -1165,12 +1166,12 @@ impl PyVersionedKvStore {
     }
 
     fn current_branch(&self) -> PyResult<String> {
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
         with_versioned_store!(guard, store, { Ok(store.current_branch().to_string()) })
     }
 
     fn list_branches(&self) -> PyResult<Vec<String>> {
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
         with_versioned_store!(guard, store, {
             store
                 .list_branches()
@@ -1182,7 +1183,7 @@ impl PyVersionedKvStore {
         // Collect commit data under lock, then release before Python GIL operations
         // to avoid potential deadlock between mutex and GIL
         let commits_data: Vec<(String, String, String, String, i64)> = {
-            let guard = self.inner.lock().unwrap();
+            let guard = self.inner.lock();
             with_versioned_store!(guard, store, {
                 let history = store
                     .log()
@@ -1231,7 +1232,7 @@ impl PyVersionedKvStore {
         // All backends now support get_commits_for_key because they all write config to dataset_dir
         // which is tracked in git commits
         let commits_data: Vec<(String, String, String, String, i64)> = {
-            let guard = self.inner.lock().unwrap();
+            let guard = self.inner.lock();
             with_versioned_store!(guard, store, {
                 let commits = store.get_commits_for_key(&key_vec).map_err(|e| {
                     PyValueError::new_err(format!("Failed to get commits for key: {}", e))
@@ -1275,7 +1276,7 @@ impl PyVersionedKvStore {
         // Collect commit data under lock, then release before Python GIL operations
         // to avoid potential deadlock between mutex and GIL
         let commits_data: Vec<(String, String, String, String, i64)> = {
-            let guard = self.inner.lock().unwrap();
+            let guard = self.inner.lock();
             with_versioned_store!(guard, store, {
                 let commits = store.get_commit_history().map_err(|e| {
                     PyValueError::new_err(format!("Failed to get commit history: {}", e))
@@ -1332,7 +1333,7 @@ impl PyVersionedKvStore {
         source_branch: String,
         conflict_resolution: Option<PyConflictResolution>,
     ) -> PyResult<String> {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
         let resolution = conflict_resolution.unwrap_or(PyConflictResolution::IgnoreAll);
 
         // All backends support merge because they all use git for version control
@@ -1371,7 +1372,7 @@ impl PyVersionedKvStore {
     ///            If success is True, conflicts will be empty and merge was applied
     ///            If success is False, conflicts contains unresolved conflicts and merge was not applied
     fn try_merge(&self, source_branch: String) -> PyResult<(bool, Vec<PyMergeConflict>)> {
-        let mut guard = self.inner.lock().unwrap();
+        let mut guard = self.inner.lock();
 
         // All backends support try_merge because they all use git for version control
         with_versioned_store_mut!(guard, store, {
@@ -1399,7 +1400,7 @@ impl PyVersionedKvStore {
     }
 
     fn storage_backend(&self) -> PyResult<PyStorageBackend> {
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
         with_versioned_store!(guard, store, { Ok(store.storage_backend().clone().into()) })
     }
 
@@ -1407,7 +1408,7 @@ impl PyVersionedKvStore {
         let key_vec = key.as_bytes().to_vec();
 
         let proof_bytes = py.allow_threads(|| {
-            let guard = self.inner.lock().unwrap();
+            let guard = self.inner.lock();
             with_versioned_store!(guard, store, {
                 let proof = store.generate_proof(&key_vec);
                 bincode::serialize(&proof).map_err(|e| {
@@ -1436,7 +1437,7 @@ impl PyVersionedKvStore {
                 PyValueError::new_err(format!("Proof deserialization failed: {}", e))
             })?;
 
-            let guard = self.inner.lock().unwrap();
+            let guard = self.inner.lock();
             with_versioned_store!(guard, store, {
                 Ok(store.verify(proof, &key_vec, value_option.as_deref()))
             })
@@ -1448,7 +1449,7 @@ impl PyVersionedKvStore {
         py: Python,
         reference: String,
     ) -> PyResult<Vec<(Py<PyBytes>, Py<PyBytes>)>> {
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
 
         // All backends now support get_keys_at_ref because they all write config to dataset_dir
         // which is committed to git history.
@@ -1489,7 +1490,7 @@ impl PyVersionedKvStore {
     /// Returns:
     ///     List[KvDiff]: List of differences between the two references
     fn diff(&self, from_ref: String, to_ref: String) -> PyResult<Vec<PyKvDiff>> {
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
 
         // All backends support diff because they all implement HistoricalAccess
         // which provides get_keys_at_ref, and diff is built on top of that.
@@ -1538,7 +1539,7 @@ impl PyVersionedKvStore {
     /// Returns:
     ///     str: The hexadecimal string representation of the current commit ID
     fn current_commit(&self) -> PyResult<String> {
-        let guard = self.inner.lock().unwrap();
+        let guard = self.inner.lock();
 
         with_versioned_store!(guard, store, {
             let commit_id = store.current_commit().map_err(|e| {
@@ -1576,7 +1577,7 @@ impl PyWorktreeManager {
         branch: String,
         create_branch: bool,
     ) -> PyResult<HashMap<String, Py<PyAny>>> {
-        let mut manager = self.inner.lock().unwrap();
+        let mut manager = self.inner.lock();
         let info = manager
             .add_worktree(path, &branch, create_branch)
             .map_err(|e| PyValueError::new_err(format!("Failed to add worktree: {}", e)))?;
@@ -1592,7 +1593,7 @@ impl PyWorktreeManager {
     }
 
     fn remove_worktree(&self, worktree_id: String) -> PyResult<()> {
-        let mut manager = self.inner.lock().unwrap();
+        let mut manager = self.inner.lock();
         manager
             .remove_worktree(&worktree_id)
             .map_err(|e| PyValueError::new_err(format!("Failed to remove worktree: {}", e)))?;
@@ -1600,7 +1601,7 @@ impl PyWorktreeManager {
     }
 
     fn lock_worktree(&self, worktree_id: String, reason: String) -> PyResult<()> {
-        let mut manager = self.inner.lock().unwrap();
+        let mut manager = self.inner.lock();
         manager
             .lock_worktree(&worktree_id, &reason)
             .map_err(|e| PyValueError::new_err(format!("Failed to lock worktree: {}", e)))?;
@@ -1608,7 +1609,7 @@ impl PyWorktreeManager {
     }
 
     fn unlock_worktree(&self, worktree_id: String) -> PyResult<()> {
-        let mut manager = self.inner.lock().unwrap();
+        let mut manager = self.inner.lock();
         manager
             .unlock_worktree(&worktree_id)
             .map_err(|e| PyValueError::new_err(format!("Failed to unlock worktree: {}", e)))?;
@@ -1616,7 +1617,7 @@ impl PyWorktreeManager {
     }
 
     fn list_worktrees(&self) -> PyResult<Vec<HashMap<String, Py<PyAny>>>> {
-        let manager = self.inner.lock().unwrap();
+        let manager = self.inner.lock();
         let worktrees = manager.list_worktrees();
 
         Python::with_gil(|py| {
@@ -1636,13 +1637,13 @@ impl PyWorktreeManager {
     }
 
     fn is_locked(&self, worktree_id: String) -> PyResult<bool> {
-        let manager = self.inner.lock().unwrap();
+        let manager = self.inner.lock();
         Ok(manager.is_locked(&worktree_id))
     }
 
     /// Merge a worktree branch back to main branch
     fn merge_to_main(&self, worktree_id: String, commit_message: String) -> PyResult<String> {
-        let mut manager = self.inner.lock().unwrap();
+        let mut manager = self.inner.lock();
         manager
             .merge_to_main(&worktree_id, &commit_message)
             .map_err(|e| PyValueError::new_err(format!("Failed to merge to main: {}", e)))
@@ -1655,7 +1656,7 @@ impl PyWorktreeManager {
         target_branch: String,
         commit_message: String,
     ) -> PyResult<String> {
-        let mut manager = self.inner.lock().unwrap();
+        let mut manager = self.inner.lock();
         manager
             .merge_branch(&source_worktree_id, &target_branch, &commit_message)
             .map_err(|e| PyValueError::new_err(format!("Failed to merge branch: {}", e)))
@@ -1663,7 +1664,7 @@ impl PyWorktreeManager {
 
     /// Get the current commit hash of a branch
     fn get_branch_commit(&self, branch: String) -> PyResult<String> {
-        let manager = self.inner.lock().unwrap();
+        let manager = self.inner.lock();
         manager
             .get_branch_commit(&branch)
             .map_err(|e| PyValueError::new_err(format!("Failed to get branch commit: {}", e)))
@@ -1671,7 +1672,7 @@ impl PyWorktreeManager {
 
     /// List all branches in the repository
     fn list_branches(&self) -> PyResult<Vec<String>> {
-        let manager = self.inner.lock().unwrap();
+        let manager = self.inner.lock();
         manager
             .list_branches()
             .map_err(|e| PyValueError::new_err(format!("Failed to list branches: {}", e)))
@@ -1716,22 +1717,22 @@ impl PyWorktreeVersionedKvStore {
     }
 
     fn worktree_id(&self) -> PyResult<String> {
-        let store = self.inner.lock().unwrap();
+        let store = self.inner.lock();
         Ok(store.worktree_id().to_string())
     }
 
     fn current_branch(&self) -> PyResult<String> {
-        let store = self.inner.lock().unwrap();
+        let store = self.inner.lock();
         Ok(store.current_branch().to_string())
     }
 
     fn is_locked(&self) -> PyResult<bool> {
-        let store = self.inner.lock().unwrap();
+        let store = self.inner.lock();
         Ok(store.is_locked())
     }
 
     fn lock(&self, reason: String) -> PyResult<()> {
-        let store = self.inner.lock().unwrap();
+        let store = self.inner.lock();
         store
             .lock(&reason)
             .map_err(|e| PyValueError::new_err(format!("Failed to lock worktree: {}", e)))?;
@@ -1739,7 +1740,7 @@ impl PyWorktreeVersionedKvStore {
     }
 
     fn unlock(&self) -> PyResult<()> {
-        let store = self.inner.lock().unwrap();
+        let store = self.inner.lock();
         store
             .unlock()
             .map_err(|e| PyValueError::new_err(format!("Failed to unlock worktree: {}", e)))?;
@@ -1748,7 +1749,7 @@ impl PyWorktreeVersionedKvStore {
 
     // Delegate key-value operations to the underlying store
     fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> PyResult<()> {
-        let mut store = self.inner.lock().unwrap();
+        let mut store = self.inner.lock();
         store
             .store_mut()
             .insert(key, value)
@@ -1757,12 +1758,12 @@ impl PyWorktreeVersionedKvStore {
     }
 
     fn get(&self, key: Vec<u8>) -> PyResult<Option<Vec<u8>>> {
-        let store = self.inner.lock().unwrap();
+        let store = self.inner.lock();
         Ok(store.store().get(&key))
     }
 
     fn delete(&self, key: Vec<u8>) -> PyResult<bool> {
-        let mut store = self.inner.lock().unwrap();
+        let mut store = self.inner.lock();
         let result = store
             .store_mut()
             .delete(&key)
@@ -1771,7 +1772,7 @@ impl PyWorktreeVersionedKvStore {
     }
 
     fn commit(&self, message: String) -> PyResult<String> {
-        let mut store = self.inner.lock().unwrap();
+        let mut store = self.inner.lock();
         let commit_id = store
             .store_mut()
             .commit(&message)
@@ -1780,7 +1781,7 @@ impl PyWorktreeVersionedKvStore {
     }
 
     fn list_keys(&self) -> PyResult<Vec<Vec<u8>>> {
-        let store = self.inner.lock().unwrap();
+        let store = self.inner.lock();
         let keys = store.store().list_keys();
 
         let total_keys = keys.len();
@@ -1837,7 +1838,7 @@ impl PyProllySQLStore {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let mut glue = self.inner.lock().unwrap();
+            let mut glue = self.inner.lock();
 
             runtime.block_on(async {
                 let results = glue
@@ -1999,7 +2000,7 @@ impl PyProllySQLStore {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-            let mut glue = self.inner.lock().unwrap();
+            let mut glue = self.inner.lock();
 
             runtime.block_on(async {
                 // Execute the COMMIT command which will trigger the underlying storage commit

--- a/src/rocksdb/storage.rs
+++ b/src/rocksdb/storage.rs
@@ -20,8 +20,11 @@ use rocksdb::{
     BlockBasedOptions, Cache, DBCompressionType, Options, SliceTransform, WriteBatch, DB,
 };
 use std::num::NonZeroUsize;
+
+const DEFAULT_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).unwrap();
+use parking_lot::Mutex;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 const CONFIG_PREFIX: &[u8] = b"config:";
 const NODE_PREFIX: &[u8] = b"node:";
@@ -40,7 +43,7 @@ impl<const N: usize> Clone for RocksDBNodeStorage<N> {
     fn clone(&self) -> Self {
         RocksDBNodeStorage {
             db: self.db.clone(),
-            cache: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap()))),
+            cache: Arc::new(Mutex::new(LruCache::new(DEFAULT_CACHE_SIZE))),
         }
     }
 }
@@ -53,7 +56,7 @@ impl<const N: usize> RocksDBNodeStorage<N> {
 
         Ok(RocksDBNodeStorage {
             db: Arc::new(db),
-            cache: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap()))),
+            cache: Arc::new(Mutex::new(LruCache::new(DEFAULT_CACHE_SIZE))),
         })
     }
 
@@ -63,7 +66,7 @@ impl<const N: usize> RocksDBNodeStorage<N> {
 
         Ok(RocksDBNodeStorage {
             db: Arc::new(db),
-            cache: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap()))),
+            cache: Arc::new(Mutex::new(LruCache::new(DEFAULT_CACHE_SIZE))),
         })
     }
 
@@ -75,7 +78,7 @@ impl<const N: usize> RocksDBNodeStorage<N> {
         Ok(RocksDBNodeStorage {
             db: Arc::new(db),
             cache: Arc::new(Mutex::new(LruCache::new(
-                NonZeroUsize::new(cache_size).unwrap_or(NonZeroUsize::new(1000).unwrap()),
+                NonZeroUsize::new(cache_size).unwrap_or(DEFAULT_CACHE_SIZE),
             ))),
         })
     }
@@ -132,7 +135,7 @@ impl<const N: usize> RocksDBNodeStorage<N> {
 impl<const N: usize> NodeStorage<N> for RocksDBNodeStorage<N> {
     fn get_node_by_hash(&self, hash: &ValueDigest<N>) -> Option<ProllyNode<N>> {
         // Check cache first
-        if let Some(node) = self.cache.lock().unwrap().get(hash) {
+        if let Some(node) = self.cache.lock().get(hash) {
             return Some(node.clone());
         }
 
@@ -147,7 +150,7 @@ impl<const N: usize> NodeStorage<N> for RocksDBNodeStorage<N> {
                         node.merged = false;
 
                         // Update cache
-                        self.cache.lock().unwrap().put(hash.clone(), node.clone());
+                        self.cache.lock().put(hash.clone(), node.clone());
 
                         Some(node)
                     }
@@ -160,7 +163,7 @@ impl<const N: usize> NodeStorage<N> for RocksDBNodeStorage<N> {
 
     fn insert_node(&mut self, hash: ValueDigest<N>, node: ProllyNode<N>) -> Option<()> {
         // Update cache
-        self.cache.lock().unwrap().put(hash.clone(), node.clone());
+        self.cache.lock().put(hash.clone(), node.clone());
 
         // Serialize and store in RocksDB
         match bincode::serialize(&node) {
@@ -177,7 +180,7 @@ impl<const N: usize> NodeStorage<N> for RocksDBNodeStorage<N> {
 
     fn delete_node(&mut self, hash: &ValueDigest<N>) -> Option<()> {
         // Remove from cache
-        self.cache.lock().unwrap().pop(hash);
+        self.cache.lock().pop(hash);
 
         // Delete from RocksDB
         let key = Self::node_key(hash);
@@ -206,7 +209,7 @@ impl<const N: usize> RocksDBNodeStorage<N> {
         nodes: Vec<(ValueDigest<N>, ProllyNode<N>)>,
     ) -> Result<(), rocksdb::Error> {
         let mut batch = WriteBatch::default();
-        let mut cache = self.cache.lock().unwrap();
+        let mut cache = self.cache.lock();
 
         for (hash, node) in nodes {
             // Update cache
@@ -231,7 +234,7 @@ impl<const N: usize> RocksDBNodeStorage<N> {
     /// Delete multiple nodes in a single batch operation
     pub fn batch_delete_nodes(&mut self, hashes: &[ValueDigest<N>]) -> Result<(), rocksdb::Error> {
         let mut batch = WriteBatch::default();
-        let mut cache = self.cache.lock().unwrap();
+        let mut cache = self.cache.lock();
 
         for hash in hashes {
             // Remove from cache

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,12 +14,12 @@ limitations under the License.
 
 use crate::digest::ValueDigest;
 use crate::node::ProllyNode;
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter, LowerHex};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::sync::RwLock;
 
 /// A trait for storage of nodes in the ProllyTree.
 ///
@@ -77,7 +77,7 @@ impl<const N: usize> Clone for InMemoryNodeStorage<N> {
     fn clone(&self) -> Self {
         InMemoryNodeStorage {
             map: self.map.clone(),
-            configs: RwLock::new(self.configs.read().unwrap().clone()),
+            configs: RwLock::new(self.configs.read().clone()),
         }
     }
 }
@@ -119,12 +119,11 @@ impl<const N: usize> NodeStorage<N> for InMemoryNodeStorage<N> {
     fn save_config(&self, key: &str, config: &[u8]) {
         self.configs
             .write()
-            .unwrap()
             .insert(key.to_string(), config.to_vec());
     }
 
     fn get_config(&self, key: &str) -> Option<Vec<u8>> {
-        self.configs.read().unwrap().get(key).cloned()
+        self.configs.read().get(key).cloned()
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -567,11 +567,10 @@ impl<const N: usize, S: NodeStorage<N>> Tree<N, S> for ProllyTree<N, S> {
                 if i == proof.path.len() - 1 {
                     return if node.is_leaf {
                         node.keys.iter().any(|k| k == key)
-                            && (expected_value.is_none()
-                                || node
-                                    .values
-                                    .iter()
-                                    .any(|v| expected_value.unwrap() == &v[..]))
+                            && match expected_value {
+                                None => true,
+                                Some(ev) => node.values.iter().any(|v| ev == &v[..]),
+                            }
                     } else {
                         false // Path should end at a leaf node
                     };
@@ -640,19 +639,19 @@ impl<const N: usize, S: NodeStorage<N>> Tree<N, S> for ProllyTree<N, S> {
         let destination_tree = self.storage.get_node_by_hash(destination_root);
         let base_tree = self.storage.get_node_by_hash(base_root);
 
-        if source_tree.is_none() || destination_tree.is_none() || base_tree.is_none() {
-            // If we can't load one of the trees, return an error as a conflict
-            return vec![MergeResult::Conflict(MergeConflict {
-                key: b"<merge_error>".to_vec(),
-                base_value: None,
-                source_value: None,
-                destination_value: Some(b"Failed to load tree from storage".to_vec()),
-            })];
-        }
-
-        let source_tree = source_tree.unwrap();
-        let destination_tree = destination_tree.unwrap();
-        let base_tree = base_tree.unwrap();
+        let (source_tree, destination_tree, base_tree) =
+            match (source_tree, destination_tree, base_tree) {
+                (Some(s), Some(d), Some(b)) => (s, d, b),
+                _ => {
+                    // If we can't load one of the trees, return an error as a conflict
+                    return vec![MergeResult::Conflict(MergeConflict {
+                        key: b"<merge_error>".to_vec(),
+                        base_value: None,
+                        source_value: None,
+                        destination_value: Some(b"Failed to load tree from storage".to_vec()),
+                    })];
+                }
+            };
 
         // Compute diffs directly using the node-level diffing
         let mut base_to_source_diffs = Vec::new();


### PR DESCRIPTION
This PR targets https://github.com/zhangfengcdt/prollytree/issues/127 by reducing panic paths in the ProllyTree ecosystem (core tree logic, encoding, git/rocksdb backends, and Python bindings) and standardizing locking to avoid unwrap() on poisoned locks.

Changes:

- Replaced several unwrap()/panic!() sites with explicit error handling (Result/Option matching) across tree verification, schema conversion, and merge logic.
- Migrated multiple mutex/RwLock usages from std::sync to parking_lot to remove poisoning-related unwrap() patterns.
- Added ProllyTreeError::InvalidDigestLength and introduced ValueDigest::try_raw_hash for non-panicking digest construction.
