### PR TITLE
GH-135 Add native namespace support to KvStore with separate subtrees

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -27,7 +27,9 @@ pub use types::{
     MergeResult,
 };
 pub use versioned_store::{
-    GitVersionedKvStore, ThreadSafeFileVersionedKvStore, ThreadSafeGitVersionedKvStore,
-    ThreadSafeInMemoryVersionedKvStore, ThreadSafeVersionedKvStore, VersionedKvStore,
+    GitNamespacedKvStore, GitVersionedKvStore, InMemoryNamespacedKvStore, NamespacedKvStore,
+    ThreadSafeFileVersionedKvStore, ThreadSafeGitNamespacedKvStore, ThreadSafeGitVersionedKvStore,
+    ThreadSafeInMemoryVersionedKvStore, ThreadSafeNamespacedKvStore, ThreadSafeVersionedKvStore,
+    VersionedKvStore,
 };
 pub use worktree::{WorktreeInfo, WorktreeManager, WorktreeVersionedKvStore};

--- a/src/git/versioned_store/backends.rs
+++ b/src/git/versioned_store/backends.rs
@@ -403,7 +403,7 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
     }
 
     /// Create a merge commit with two parents (current HEAD + source branch)
-    fn create_merge_commit(
+    pub(crate) fn create_merge_commit(
         &mut self,
         message: &str,
         source_branch: &str,

--- a/src/git/versioned_store/mod.rs
+++ b/src/git/versioned_store/mod.rs
@@ -57,9 +57,26 @@ limitations under the License.
 mod backends;
 mod core;
 mod history;
+pub mod namespaced;
+#[cfg(test)]
+mod namespaced_tests;
 #[cfg(test)]
 mod tests;
 mod thread_safe;
+
+/// Global mutex to serialize CWD access in tests.
+///
+/// Many tests change the process-wide working directory via `CwdGuard`.
+/// Without serialization, parallel tests race on `std::env::set_current_dir`
+/// and fail intermittently. Both `tests.rs` and `namespaced_tests.rs` share
+/// this mutex to prevent those races.
+#[cfg(test)]
+pub(super) static CWD_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+
+#[cfg(test)]
+pub(super) fn cwd_lock() -> &'static std::sync::Mutex<()> {
+    CWD_LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
 
 use crate::git::metadata::{GitMetadataBackend, MetadataBackend};
 use crate::git::types::*;
@@ -195,6 +212,20 @@ pub type ThreadSafeFileVersionedKvStore<const N: usize> =
 #[cfg(feature = "rocksdb_storage")]
 pub type ThreadSafeRocksDBVersionedKvStore<const N: usize> =
     ThreadSafeVersionedKvStore<N, RocksDBNodeStorage<N>>;
+
+// ---------------------------------------------------------------------------
+// Re-export namespaced types
+// ---------------------------------------------------------------------------
+
+pub use namespaced::{
+    FileNamespacedKvStore, GitNamespacedKvStore, InMemoryNamespacedKvStore, MigrationReport,
+    NamespaceEntry, NamespaceHandle, NamespacedKvStore, StoreFormatVersion,
+    ThreadSafeGitNamespacedKvStore, ThreadSafeInMemoryNamespacedKvStore,
+    ThreadSafeNamespacedKvStore, DEFAULT_NAMESPACE,
+};
+
+#[cfg(feature = "rocksdb_storage")]
+pub use namespaced::RocksDBNamespacedKvStore;
 
 // ---------------------------------------------------------------------------
 // StoreFactory — simplified API for creating versioned stores

--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -1,0 +1,1561 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Namespace-aware versioned key-value store.
+//!
+//! [`NamespacedKvStore`] wraps a [`VersionedKvStore`] and adds native namespace
+//! support where each namespace is backed by its own [`ProllyTree`] subtree.
+//! A namespace registry maps namespace names to their subtree root hashes,
+//! enabling O(1) change detection and efficient namespace-scoped operations.
+//!
+//! # Architecture
+//!
+//! ```text
+//! NamespacedKvStore
+//! ├── inner: VersionedKvStore   (git plumbing: commits, branches, refs)
+//! ├── registry: HashMap<String, NamespaceEntry>  (namespace → root hash + config)
+//! ├── namespaces: HashMap<String, ProllyTree>    (lazily loaded subtrees)
+//! ├── namespace_staging: HashMap<String, ...>     (per-namespace staging areas)
+//! └── dirty_namespaces: HashSet<String>           (modified since last commit)
+//! ```
+//!
+//! All namespace trees share the same [`NodeStorage`] backend (content-addressed,
+//! so there is no collision risk).
+
+use super::{TreeConfigSaver, VersionedKvStore};
+use crate::config::TreeConfig;
+use crate::diff::{ConflictResolver, IgnoreConflictsResolver, MergeConflict};
+use crate::digest::ValueDigest;
+use crate::git::metadata::{GitMetadataBackend, MetadataBackend};
+use crate::git::types::*;
+use crate::storage::{GitNodeStorage, InMemoryNodeStorage, NodeStorage};
+use crate::tree::{ProllyTree, Tree};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::storage::FileNodeStorage;
+
+#[cfg(feature = "rocksdb_storage")]
+use crate::storage::RocksDBNodeStorage;
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+/// Storage format version for detecting V1 (flat) vs V2 (namespaced) stores.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum StoreFormatVersion {
+    /// Legacy flat store — single ProllyTree, no namespaces.
+    V1,
+    /// Namespaced store — registry + per-namespace subtrees.
+    V2,
+}
+
+/// Serializable entry for a single namespace in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamespaceEntry<const N: usize> {
+    /// Root hash of the namespace's ProllyTree (None if empty / newly created).
+    pub root_hash: Option<ValueDigest<N>>,
+    /// TreeConfig for this namespace's ProllyTree.
+    pub config: TreeConfig<N>,
+}
+
+/// Report returned by [`NamespacedKvStore::migrate_v1_to_v2`].
+#[derive(Debug, Clone)]
+pub struct MigrationReport {
+    pub keys_migrated: usize,
+    pub namespaces_created: Vec<String>,
+    pub storage_version: StoreFormatVersion,
+}
+
+/// The default namespace name used for backward-compatible flat API calls.
+pub const DEFAULT_NAMESPACE: &str = "default";
+
+// ---------------------------------------------------------------------------
+// NamespacedKvStore
+// ---------------------------------------------------------------------------
+
+/// A namespace-aware versioned key-value store.
+///
+/// Each namespace is backed by its own [`ProllyTree`] subtree, with a registry
+/// mapping namespace names to subtree root hashes. This enables:
+///
+/// - **O(1) change detection**: compare 32-byte root hashes per namespace.
+/// - **Efficient scoped operations**: namespace list/delete without full scan.
+/// - **Clean isolation**: keys in different namespaces live in separate trees.
+/// - **Scalable merge**: skip unchanged namespaces entirely.
+///
+/// The struct wraps a [`VersionedKvStore`] which handles all git plumbing
+/// (commits, branches, refs, staging files to git).
+pub struct NamespacedKvStore<
+    const N: usize,
+    S: NodeStorage<N>,
+    M: MetadataBackend = GitMetadataBackend,
+> {
+    /// Underlying versioned store — handles git metadata (commits, branches, HEAD).
+    pub(crate) inner: VersionedKvStore<N, S, M>,
+    /// Registry: namespace name → entry (root hash + config).
+    pub(crate) registry: HashMap<String, NamespaceEntry<N>>,
+    /// Lazily loaded per-namespace ProllyTree instances.
+    pub(crate) namespaces: HashMap<String, ProllyTree<N, S>>,
+    /// Per-namespace staging areas. `None` value = deletion.
+    pub(crate) namespace_staging: HashMap<String, HashMap<Vec<u8>, Option<Vec<u8>>>>,
+    /// Default namespace name for backward-compatible operations.
+    pub(crate) default_namespace: String,
+    /// Tracks which namespaces have been modified since last commit.
+    pub(crate) dirty_namespaces: HashSet<String>,
+    /// Store format version (V1 = flat/legacy, V2 = namespaced).
+    pub(crate) format_version: StoreFormatVersion,
+}
+
+// ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+/// Type alias for Git-backed namespaced store.
+pub type GitNamespacedKvStore<const N: usize> = NamespacedKvStore<N, GitNodeStorage<N>>;
+
+/// Type alias for in-memory namespaced store.
+pub type InMemoryNamespacedKvStore<const N: usize> = NamespacedKvStore<N, InMemoryNodeStorage<N>>;
+
+/// Type alias for file-backed namespaced store.
+pub type FileNamespacedKvStore<const N: usize> = NamespacedKvStore<N, FileNodeStorage<N>>;
+
+/// Type alias for RocksDB-backed namespaced store.
+#[cfg(feature = "rocksdb_storage")]
+pub type RocksDBNamespacedKvStore<const N: usize> = NamespacedKvStore<N, RocksDBNodeStorage<N>>;
+
+// ---------------------------------------------------------------------------
+// Thread-safe wrapper
+// ---------------------------------------------------------------------------
+
+/// Thread-safe wrapper for [`NamespacedKvStore`].
+///
+/// Uses `Arc<parking_lot::Mutex<..>>` for safe multi-threaded access.
+/// `NamespaceHandle` borrows cannot escape the lock scope, so this wrapper
+/// provides direct `ns_*` methods instead.
+pub struct ThreadSafeNamespacedKvStore<
+    const N: usize,
+    S: NodeStorage<N>,
+    M: MetadataBackend = GitMetadataBackend,
+> {
+    pub(crate) inner: Arc<Mutex<NamespacedKvStore<N, S, M>>>,
+}
+
+/// Type alias for thread-safe Git-backed namespaced store.
+pub type ThreadSafeGitNamespacedKvStore<const N: usize> =
+    ThreadSafeNamespacedKvStore<N, GitNodeStorage<N>>;
+
+/// Type alias for thread-safe in-memory namespaced store.
+pub type ThreadSafeInMemoryNamespacedKvStore<const N: usize> =
+    ThreadSafeNamespacedKvStore<N, InMemoryNodeStorage<N>>;
+
+// ---------------------------------------------------------------------------
+// NamespaceHandle — borrowed view into a single namespace
+// ---------------------------------------------------------------------------
+
+/// A handle to a specific namespace within a [`NamespacedKvStore`].
+///
+/// This is a short-lived mutable reference that provides namespace-scoped
+/// operations. It is created by [`NamespacedKvStore::namespace`].
+pub struct NamespaceHandle<'a, const N: usize, S: NodeStorage<N>, M: MetadataBackend> {
+    store: &'a mut NamespacedKvStore<N, S, M>,
+    ns_name: String,
+}
+
+impl<'a, const N: usize, S: NodeStorage<N>, M: MetadataBackend> NamespaceHandle<'a, N, S, M> {
+    /// Get a value by key within this namespace.
+    ///
+    /// Checks the namespace's staging area first, then the committed tree.
+    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        // Check namespace staging area first
+        if let Some(staging) = self.store.namespace_staging.get(&self.ns_name) {
+            if let Some(staged_value) = staging.get(key) {
+                return staged_value.clone();
+            }
+        }
+
+        // Check committed tree
+        if let Some(tree) = self.store.namespaces.get(&self.ns_name) {
+            return tree.find(key).and_then(|node| {
+                node.keys
+                    .iter()
+                    .position(|k| k == key)
+                    .map(|idx| node.values[idx].clone())
+            });
+        }
+
+        None
+    }
+
+    /// Insert a key-value pair within this namespace (stages the change).
+    pub fn insert(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), GitKvError> {
+        crate::validation::validate_kv(&key, &value)?;
+        self.store
+            .namespace_staging
+            .entry(self.ns_name.clone())
+            .or_default()
+            .insert(key, Some(value));
+        self.store.dirty_namespaces.insert(self.ns_name.clone());
+        Ok(())
+    }
+
+    /// Delete a key within this namespace (stages the deletion).
+    pub fn delete(&mut self, key: &[u8]) -> Result<bool, GitKvError> {
+        let exists = self.get(key).is_some();
+        if exists {
+            self.store
+                .namespace_staging
+                .entry(self.ns_name.clone())
+                .or_default()
+                .insert(key.to_vec(), None);
+            self.store.dirty_namespaces.insert(self.ns_name.clone());
+        }
+        Ok(exists)
+    }
+
+    /// List all keys within this namespace (includes staged changes).
+    pub fn list_keys(&self) -> Vec<Vec<u8>> {
+        let mut keys = HashSet::new();
+
+        // Add keys from the committed tree
+        if let Some(tree) = self.store.namespaces.get(&self.ns_name) {
+            for key in tree.collect_keys() {
+                keys.insert(key);
+            }
+        }
+
+        // Apply staging area
+        if let Some(staging) = self.store.namespace_staging.get(&self.ns_name) {
+            for (key, value) in staging {
+                if value.is_some() {
+                    keys.insert(key.clone());
+                } else {
+                    keys.remove(key);
+                }
+            }
+        }
+
+        let mut result: Vec<Vec<u8>> = keys.into_iter().collect();
+        result.sort();
+        result
+    }
+
+    /// Get the root hash of this namespace's ProllyTree.
+    pub fn root_hash(&self) -> Option<ValueDigest<N>> {
+        self.store
+            .namespaces
+            .get(&self.ns_name)
+            .and_then(|tree| tree.get_root_hash())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core operations (generic over all storage backends)
+// ---------------------------------------------------------------------------
+
+impl<const N: usize, S: NodeStorage<N>, M: MetadataBackend> NamespacedKvStore<N, S, M>
+where
+    VersionedKvStore<N, S, M>: TreeConfigSaver<N>,
+{
+    // -- Namespace handle ---------------------------------------------------
+
+    /// Get a mutable handle to a namespace. Creates the namespace lazily if
+    /// it does not yet exist.
+    pub fn namespace(&mut self, prefix: &str) -> NamespaceHandle<'_, N, S, M> {
+        // Ensure the namespace ProllyTree exists in-memory
+        if !self.namespaces.contains_key(prefix) {
+            // Check if we have a registry entry to load from
+            if let Some(entry) = self.registry.get(prefix) {
+                // Try loading from storage
+                let tree = if entry.root_hash.is_some() {
+                    ProllyTree::load_from_storage(
+                        self.inner.tree.storage.clone(),
+                        entry.config.clone(),
+                    )
+                    .unwrap_or_else(|| {
+                        ProllyTree::new(self.inner.tree.storage.clone(), entry.config.clone())
+                    })
+                } else {
+                    ProllyTree::new(self.inner.tree.storage.clone(), entry.config.clone())
+                };
+                self.namespaces.insert(prefix.to_string(), tree);
+            } else {
+                // New namespace — create empty tree
+                let tree = ProllyTree::new(self.inner.tree.storage.clone(), TreeConfig::default());
+                self.namespaces.insert(prefix.to_string(), tree);
+                self.dirty_namespaces.insert(prefix.to_string());
+            }
+        }
+
+        // Ensure staging area exists
+        self.namespace_staging
+            .entry(prefix.to_string())
+            .or_default();
+
+        NamespaceHandle {
+            store: self,
+            ns_name: prefix.to_string(),
+        }
+    }
+
+    // -- Registry operations ------------------------------------------------
+
+    /// List all namespace names (sorted).
+    pub fn list_namespaces(&self) -> Vec<String> {
+        let mut names: HashSet<String> = HashSet::new();
+        names.extend(self.registry.keys().cloned());
+        names.extend(self.namespaces.keys().cloned());
+        let mut result: Vec<String> = names.into_iter().collect();
+        result.sort();
+        result
+    }
+
+    /// Delete an entire namespace. Returns `true` if the namespace existed.
+    ///
+    /// The "default" namespace cannot be deleted.
+    pub fn delete_namespace(&mut self, prefix: &str) -> Result<bool, GitKvError> {
+        if prefix == self.default_namespace {
+            return Err(GitKvError::GitObjectError(
+                "Cannot delete the default namespace".to_string(),
+            ));
+        }
+        let existed =
+            self.registry.remove(prefix).is_some() || self.namespaces.remove(prefix).is_some();
+        self.namespace_staging.remove(prefix);
+        self.dirty_namespaces.remove(prefix);
+        Ok(existed)
+    }
+
+    /// Get the root hash for a namespace (O(1) lookup).
+    pub fn get_namespace_root_hash(&self, prefix: &str) -> Option<ValueDigest<N>> {
+        // Check in-memory tree first (may have uncommitted changes)
+        if let Some(tree) = self.namespaces.get(prefix) {
+            return tree.get_root_hash();
+        }
+        // Fall back to registry entry
+        self.registry
+            .get(prefix)
+            .and_then(|entry| entry.root_hash.clone())
+    }
+
+    // -- Backward-compatible flat API (operates on default namespace) -------
+
+    /// Insert a key-value pair into the default namespace.
+    pub fn insert(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), GitKvError> {
+        let ns = self.default_namespace.clone();
+        self.namespace(&ns).insert(key, value)
+    }
+
+    /// Get a value by key from the default namespace.
+    pub fn get(&mut self, key: &[u8]) -> Option<Vec<u8>> {
+        let ns = self.default_namespace.clone();
+        self.namespace(&ns).get(key)
+    }
+
+    /// Delete a key from the default namespace.
+    pub fn delete(&mut self, key: &[u8]) -> Result<bool, GitKvError> {
+        let ns = self.default_namespace.clone();
+        self.namespace(&ns).delete(key)
+    }
+
+    /// List all keys in the default namespace.
+    pub fn list_keys(&mut self) -> Vec<Vec<u8>> {
+        let ns = self.default_namespace.clone();
+        self.namespace(&ns).list_keys()
+    }
+
+    // -- Git operations -----------------------------------------------------
+
+    /// Get current branch name.
+    pub fn current_branch(&self) -> &str {
+        self.inner.current_branch()
+    }
+
+    /// List all branches.
+    pub fn list_branches(&self) -> Result<Vec<String>, GitKvError> {
+        self.inner.list_branches()
+    }
+
+    /// Get commit history.
+    pub fn log(&self) -> Result<Vec<CommitInfo>, GitKvError> {
+        self.inner.log()
+    }
+
+    /// Create a new branch from the current branch and switch to it.
+    pub fn create_branch(&mut self, name: &str) -> Result<(), GitKvError> {
+        self.inner.create_branch(name)?;
+        // Clear per-namespace staging since we switched branches
+        self.namespace_staging.clear();
+        self.dirty_namespaces.clear();
+        Ok(())
+    }
+
+    // -- Persistence helpers ------------------------------------------------
+
+    /// Save namespace registry to the dataset directory.
+    fn save_namespace_registry(&self) -> Result<(), GitKvError> {
+        let dataset_dir = self
+            .inner
+            .dataset_dir
+            .as_ref()
+            .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".into()))?;
+
+        // Write version marker
+        let version_path = dataset_dir.join("prolly_namespace_version");
+        std::fs::write(&version_path, "V2").map_err(|e| {
+            GitKvError::GitObjectError(format!("Failed to write namespace version: {e}"))
+        })?;
+
+        // Build registry from current namespace state
+        let mut registry_data: HashMap<String, NamespaceEntry<N>> = self.registry.clone();
+        for (ns_name, tree) in &self.namespaces {
+            registry_data.insert(
+                ns_name.clone(),
+                NamespaceEntry {
+                    root_hash: tree.get_root_hash(),
+                    config: tree.config.clone(),
+                },
+            );
+        }
+
+        // Write registry
+        let registry_json = serde_json::to_string_pretty(&registry_data).map_err(|e| {
+            GitKvError::GitObjectError(format!("Failed to serialize namespace registry: {e}"))
+        })?;
+        let registry_path = dataset_dir.join("prolly_namespace_registry");
+        std::fs::write(&registry_path, registry_json).map_err(|e| {
+            GitKvError::GitObjectError(format!("Failed to write namespace registry: {e}"))
+        })?;
+
+        Ok(())
+    }
+
+    /// Load namespace registry from the dataset directory.
+    fn load_namespace_registry(&mut self) -> Result<(), GitKvError> {
+        let dataset_dir = self
+            .inner
+            .dataset_dir
+            .as_ref()
+            .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".into()))?
+            .clone();
+
+        let registry_path = dataset_dir.join("prolly_namespace_registry");
+        if !registry_path.exists() {
+            return Ok(());
+        }
+
+        let registry_json = std::fs::read_to_string(&registry_path).map_err(|e| {
+            GitKvError::GitObjectError(format!("Failed to read namespace registry: {e}"))
+        })?;
+
+        let registry: HashMap<String, NamespaceEntry<N>> = serde_json::from_str(&registry_json)
+            .map_err(|e| {
+                GitKvError::GitObjectError(format!("Failed to parse namespace registry: {e}"))
+            })?;
+
+        self.registry = registry;
+        Ok(())
+    }
+
+    /// Detect store format version from the dataset directory.
+    fn detect_format_version(dataset_dir: &Path) -> StoreFormatVersion {
+        let version_path = dataset_dir.join("prolly_namespace_version");
+        if version_path.exists() {
+            if let Ok(content) = std::fs::read_to_string(version_path) {
+                if content.trim() == "V2" {
+                    return StoreFormatVersion::V2;
+                }
+            }
+        }
+        StoreFormatVersion::V1
+    }
+
+    // -- Commit -------------------------------------------------------------
+
+    /// Core commit logic shared by all backends.
+    ///
+    /// 1. Drains each dirty namespace's staging into its ProllyTree.
+    /// 2. Updates the registry with current root hashes.
+    /// 3. Writes namespace config files to the dataset directory.
+    /// 4. Delegates to `inner.commit()` for the actual git commit.
+    ///
+    /// Backend-specific `commit()` methods may wrap this with additional
+    /// steps (e.g., merging hash mappings for Git storage).
+    pub(crate) fn commit_impl(&mut self, message: &str) -> Result<gix::ObjectId, GitKvError> {
+        // 1. For each dirty namespace, drain staging into tree
+        let dirty: Vec<String> = self.dirty_namespaces.drain().collect();
+        for ns_name in &dirty {
+            if let Some(staging) = self.namespace_staging.get_mut(ns_name) {
+                // Ensure the tree exists
+                if !self.namespaces.contains_key(ns_name) {
+                    let config = self
+                        .registry
+                        .get(ns_name)
+                        .map(|e| e.config.clone())
+                        .unwrap_or_default();
+                    let tree = ProllyTree::new(self.inner.tree.storage.clone(), config);
+                    self.namespaces.insert(ns_name.clone(), tree);
+                }
+
+                if let Some(tree) = self.namespaces.get_mut(ns_name) {
+                    for (key, value) in staging.drain() {
+                        match value {
+                            Some(v) => {
+                                tree.insert(key, v);
+                            }
+                            None => {
+                                tree.delete(&key);
+                            }
+                        }
+                    }
+                    tree.persist_root();
+                }
+            }
+        }
+
+        // 2. Update registry entries with current root hashes
+        for (ns_name, tree) in &self.namespaces {
+            self.registry.insert(
+                ns_name.clone(),
+                NamespaceEntry {
+                    root_hash: tree.get_root_hash(),
+                    config: tree.config.clone(),
+                },
+            );
+        }
+
+        // 3. Write namespace registry + version to dataset dir
+        self.save_namespace_registry()?;
+
+        // 4. Delegate to inner for the git commit
+        // (inner.commit drains its own empty staging, persists its placeholder tree,
+        //  writes prolly_config_tree_config, stages ALL dataset_dir files via git add,
+        //  creates the git commit, updates refs)
+        //
+        self.inner.commit(message)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Git-specific backend (init / open / checkout / merge)
+// ---------------------------------------------------------------------------
+
+impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> {
+    /// Merge hash mappings from namespace trees into the inner store's
+    /// Git storage, so all mappings are written to `prolly_hash_mappings`
+    /// during commit.
+    fn merge_ns_hash_mappings_to_inner_git(&self) {
+        for tree in self.namespaces.values() {
+            let ns_mappings = tree.storage.get_hash_mappings();
+            self.inner.tree.storage.merge_hash_mappings(ns_mappings);
+        }
+    }
+
+    /// Commit staged changes across all namespaces.
+    ///
+    /// Before delegating to the generic commit logic, merges hash mappings
+    /// from namespace subtrees into the inner store's `GitNodeStorage` so
+    /// that `save_tree_config_to_git()` writes all mappings to
+    /// `prolly_hash_mappings`.
+    pub fn commit(&mut self, message: &str) -> Result<gix::ObjectId, GitKvError> {
+        // First run the generic commit logic (drains staging, persists trees, etc.)
+        // We need to call commit_impl first so trees are persisted before we merge mappings
+        // Actually, commit_impl also calls inner.commit(). We need to merge BEFORE inner.commit.
+        // So we split: do the namespace work ourselves, merge mappings, then call inner.commit.
+
+        // 1. Drain staging into namespace trees
+        let dirty: Vec<String> = self.dirty_namespaces.drain().collect();
+        for ns_name in &dirty {
+            if let Some(staging) = self.namespace_staging.get_mut(ns_name) {
+                if !self.namespaces.contains_key(ns_name) {
+                    let config = self
+                        .registry
+                        .get(ns_name)
+                        .map(|e| e.config.clone())
+                        .unwrap_or_default();
+                    let tree = ProllyTree::new(self.inner.tree.storage.clone(), config);
+                    self.namespaces.insert(ns_name.clone(), tree);
+                }
+                if let Some(tree) = self.namespaces.get_mut(ns_name) {
+                    for (key, value) in staging.drain() {
+                        match value {
+                            Some(v) => tree.insert(key, v),
+                            None => {
+                                tree.delete(&key);
+                            }
+                        }
+                    }
+                    tree.persist_root();
+                }
+            }
+        }
+
+        // 2. Update registry
+        for (ns_name, tree) in &self.namespaces {
+            self.registry.insert(
+                ns_name.clone(),
+                NamespaceEntry {
+                    root_hash: tree.get_root_hash(),
+                    config: tree.config.clone(),
+                },
+            );
+        }
+
+        // 3. Write namespace files
+        self.save_namespace_registry()?;
+
+        // 4. Merge namespace hash mappings into inner storage
+        self.merge_ns_hash_mappings_to_inner_git();
+
+        // 5. Delegate to inner for git commit
+        self.inner.commit(message)
+    }
+
+    /// Initialize a new namespaced store with Git storage.
+    pub fn init<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        // Delegate to VersionedKvStore for git setup
+        let inner = VersionedKvStore::<N, GitNodeStorage<N>>::init(&path)?;
+
+        let mut store = NamespacedKvStore {
+            inner,
+            registry: HashMap::new(),
+            namespaces: HashMap::new(),
+            namespace_staging: HashMap::new(),
+            default_namespace: DEFAULT_NAMESPACE.to_string(),
+            dirty_namespaces: HashSet::new(),
+            format_version: StoreFormatVersion::V2,
+        };
+
+        // Create the default namespace with an empty tree
+        let default_tree = ProllyTree::new(store.inner.tree.storage.clone(), TreeConfig::default());
+        store
+            .namespaces
+            .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+
+        // Commit initial state (writes V2 marker + registry)
+        store.commit("Initial namespaced store")?;
+
+        Ok(store)
+    }
+
+    /// Open an existing store. Automatically detects V1/V2 format.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        let inner = VersionedKvStore::<N, GitNodeStorage<N>>::open(&path)?;
+
+        let dataset_dir = inner
+            .dataset_dir
+            .as_ref()
+            .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".into()))?;
+        let format_version = Self::detect_format_version(dataset_dir);
+
+        let mut store = NamespacedKvStore {
+            inner,
+            registry: HashMap::new(),
+            namespaces: HashMap::new(),
+            namespace_staging: HashMap::new(),
+            default_namespace: DEFAULT_NAMESPACE.to_string(),
+            dirty_namespaces: HashSet::new(),
+            format_version: format_version.clone(),
+        };
+
+        match format_version {
+            StoreFormatVersion::V2 => {
+                // Load namespace registry; trees are loaded lazily on access
+                store.load_namespace_registry()?;
+            }
+            StoreFormatVersion::V1 => {
+                // V1: wrap inner tree data as the "default" namespace.
+                // Collect current tree data into a new namespace tree.
+                let mut kv_pairs = Vec::new();
+                for key in store.inner.tree.collect_keys() {
+                    if let Some(value) = store.inner.get(&key) {
+                        kv_pairs.push((key, value));
+                    }
+                }
+
+                if !kv_pairs.is_empty() {
+                    let mut default_tree =
+                        ProllyTree::new(store.inner.tree.storage.clone(), TreeConfig::default());
+                    for (key, value) in kv_pairs {
+                        default_tree.insert(key, value);
+                    }
+                    default_tree.persist_root();
+                    store
+                        .namespaces
+                        .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+                } else {
+                    let default_tree =
+                        ProllyTree::new(store.inner.tree.storage.clone(), TreeConfig::default());
+                    store
+                        .namespaces
+                        .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+                }
+            }
+        }
+
+        Ok(store)
+    }
+
+    /// Checkout a branch or commit. Reloads namespace state from the target.
+    pub fn checkout(&mut self, branch_or_commit: &str) -> Result<(), GitKvError> {
+        // Clear all namespace state
+        self.namespace_staging.clear();
+        self.dirty_namespaces.clear();
+        self.namespaces.clear();
+        self.registry.clear();
+
+        // Delegate to inner for git checkout (updates HEAD, reloads inner tree)
+        self.inner.checkout(branch_or_commit)?;
+
+        // Load the namespace registry from the HEAD commit (not from disk,
+        // because the file on disk may reflect a different branch's last commit).
+        let head_commit = self.inner.metadata.head_commit_id()?;
+        let registry_at_head = self.load_registry_at_commit(&head_commit)?;
+
+        if !registry_at_head.is_empty() {
+            self.registry = registry_at_head;
+            self.format_version = StoreFormatVersion::V2;
+
+            // Also update the on-disk files to match the checked-out commit
+            self.save_namespace_registry()?;
+        } else {
+            // No registry at this commit — either V1 or pre-namespace commit
+            self.format_version = StoreFormatVersion::V1;
+        }
+
+        Ok(())
+    }
+
+    /// Merge another branch into the current branch with namespace-aware
+    /// three-way merge.
+    ///
+    /// For each namespace:
+    /// - If root hash unchanged between base and source: skip (no change).
+    /// - If only source changed: take source namespace state.
+    /// - If only dest changed: keep dest (no-op).
+    /// - If both changed: perform key-level three-way merge within namespace.
+    pub fn merge<R: ConflictResolver>(
+        &mut self,
+        source_branch: &str,
+        resolver: &R,
+    ) -> Result<gix::ObjectId, GitKvError> {
+        let dest_branch = self.inner.current_branch.clone();
+
+        // Find merge base
+        let base_commit = self.find_merge_base(&dest_branch, source_branch)?;
+        let source_commit = self.get_branch_commit(source_branch)?;
+
+        // Load registries at base and source commits
+        let base_registry = self.load_registry_at_commit(&base_commit)?;
+        let source_registry = self.load_registry_at_commit(&source_commit)?;
+
+        // Current (dest) registry
+        let dest_registry = self.current_registry_snapshot();
+
+        // Collect all namespace names
+        let mut all_ns: HashSet<String> = HashSet::new();
+        all_ns.extend(base_registry.keys().cloned());
+        all_ns.extend(source_registry.keys().cloned());
+        all_ns.extend(dest_registry.keys().cloned());
+
+        let mut unresolved_conflicts: Vec<MergeConflict> = Vec::new();
+
+        for ns_name in &all_ns {
+            let base_hash = base_registry.get(ns_name).and_then(|e| e.root_hash.clone());
+            let source_hash = source_registry
+                .get(ns_name)
+                .and_then(|e| e.root_hash.clone());
+            let dest_hash = dest_registry.get(ns_name).and_then(|e| e.root_hash.clone());
+
+            // If source hash == dest hash, no merge needed for this namespace
+            if source_hash == dest_hash {
+                continue;
+            }
+
+            // If base hash == dest hash (only source changed), take source
+            if base_hash == dest_hash && source_hash != dest_hash {
+                // Load source namespace state and replace dest
+                let source_kv =
+                    self.collect_ns_keys_at_commit(ns_name, &source_commit, &source_registry)?;
+                let mut tree = ProllyTree::new(
+                    self.inner.tree.storage.clone(),
+                    source_registry
+                        .get(ns_name)
+                        .map(|e| e.config.clone())
+                        .unwrap_or_default(),
+                );
+                for (key, value) in source_kv {
+                    tree.insert(key, value);
+                }
+                tree.persist_root();
+                self.namespaces.insert(ns_name.clone(), tree);
+                continue;
+            }
+
+            // If base hash == source hash (only dest changed), keep dest (no-op)
+            if base_hash == source_hash {
+                continue;
+            }
+
+            // Both changed — key-level three-way merge within this namespace
+            let base_kv = self.collect_ns_keys_at_commit(ns_name, &base_commit, &base_registry)?;
+            let source_kv =
+                self.collect_ns_keys_at_commit(ns_name, &source_commit, &source_registry)?;
+
+            // Get dest KV from in-memory tree
+            let mut dest_kv = HashMap::new();
+            if let Some(tree) = self.namespaces.get(ns_name) {
+                for key in tree.collect_keys() {
+                    if let Some(node) = tree.find(&key) {
+                        if let Some(idx) = node.keys.iter().position(|k| k == &key) {
+                            dest_kv.insert(key, node.values[idx].clone());
+                        }
+                    }
+                }
+            }
+
+            // Three-way merge at key level
+            let mut all_keys: HashSet<Vec<u8>> = HashSet::new();
+            all_keys.extend(base_kv.keys().cloned());
+            all_keys.extend(source_kv.keys().cloned());
+            all_keys.extend(dest_kv.keys().cloned());
+
+            let mut merge_results = Vec::new();
+
+            for key in &all_keys {
+                let base_val = base_kv.get(key);
+                let source_val = source_kv.get(key);
+                let dest_val = dest_kv.get(key);
+
+                match (base_val, source_val, dest_val) {
+                    (Some(b), Some(s), Some(d)) => {
+                        if b == s && b == d {
+                            continue;
+                        } else if b == d && b != s {
+                            merge_results
+                                .push(crate::diff::MergeResult::Modified(key.clone(), s.clone()));
+                        } else if b == s || s == d {
+                            continue;
+                        } else {
+                            let conflict = MergeConflict {
+                                key: key.clone(),
+                                base_value: Some(b.clone()),
+                                source_value: Some(s.clone()),
+                                destination_value: Some(d.clone()),
+                            };
+                            merge_results.push(crate::diff::MergeResult::Conflict(conflict));
+                        }
+                    }
+                    (None, Some(s), None) => {
+                        merge_results.push(crate::diff::MergeResult::Added(key.clone(), s.clone()));
+                    }
+                    (None, Some(s), Some(d)) => {
+                        if s == d {
+                            continue;
+                        } else {
+                            let conflict = MergeConflict {
+                                key: key.clone(),
+                                base_value: None,
+                                source_value: Some(s.clone()),
+                                destination_value: Some(d.clone()),
+                            };
+                            merge_results.push(crate::diff::MergeResult::Conflict(conflict));
+                        }
+                    }
+                    (Some(_), None, Some(_)) => {
+                        merge_results.push(crate::diff::MergeResult::Removed(key.clone()));
+                    }
+                    _ => continue,
+                }
+            }
+
+            // Resolve conflicts
+            let mut resolved = Vec::new();
+            for result in merge_results {
+                match result {
+                    crate::diff::MergeResult::Conflict(conflict) => {
+                        if let Some(resolved_result) = resolver.resolve_conflict(&conflict) {
+                            resolved.push(resolved_result);
+                        } else {
+                            unresolved_conflicts.push(conflict);
+                        }
+                    }
+                    other => resolved.push(other),
+                }
+            }
+
+            // Apply to namespace tree
+            // Ensure tree is loaded
+            if !self.namespaces.contains_key(ns_name) {
+                let tree = ProllyTree::new(self.inner.tree.storage.clone(), TreeConfig::default());
+                self.namespaces.insert(ns_name.clone(), tree);
+            }
+            if let Some(tree) = self.namespaces.get_mut(ns_name) {
+                for result in resolved {
+                    match result {
+                        crate::diff::MergeResult::Added(key, value)
+                        | crate::diff::MergeResult::Modified(key, value) => {
+                            tree.insert(key, value);
+                        }
+                        crate::diff::MergeResult::Removed(key) => {
+                            tree.delete(&key);
+                        }
+                        crate::diff::MergeResult::Conflict(_) => unreachable!(),
+                    }
+                }
+                tree.persist_root();
+            }
+        }
+
+        if !unresolved_conflicts.is_empty() {
+            return Err(GitKvError::MergeConflictError(unresolved_conflicts));
+        }
+
+        // Clear staging
+        self.namespace_staging.clear();
+        self.dirty_namespaces.clear();
+
+        // Save namespace registry and create merge commit
+        self.save_namespace_registry()?;
+
+        // Update inner registry entries
+        for (ns_name, tree) in &self.namespaces {
+            self.registry.insert(
+                ns_name.clone(),
+                NamespaceEntry {
+                    root_hash: tree.get_root_hash(),
+                    config: tree.config.clone(),
+                },
+            );
+        }
+
+        self.inner.create_merge_commit_for_namespaced(source_branch)
+    }
+
+    /// Migrate a V1 (flat) store to V2 (namespaced) format.
+    ///
+    /// All existing key-value pairs are moved into the "default" namespace.
+    pub fn migrate_v1_to_v2(&mut self) -> Result<MigrationReport, GitKvError> {
+        if self.format_version == StoreFormatVersion::V2 {
+            return Err(GitKvError::GitObjectError(
+                "Store is already V2 format".to_string(),
+            ));
+        }
+
+        // Collect all KV from the inner (flat) tree
+        let mut kv_pairs = Vec::new();
+        for key in self.inner.tree.collect_keys() {
+            if let Some(value) = self.inner.get(&key) {
+                kv_pairs.push((key, value));
+            }
+        }
+        let keys_migrated = kv_pairs.len();
+
+        // Create "default" namespace tree and insert all KV
+        let mut default_tree =
+            ProllyTree::new(self.inner.tree.storage.clone(), TreeConfig::default());
+        for (key, value) in kv_pairs {
+            default_tree.insert(key, value);
+        }
+        default_tree.persist_root();
+
+        self.namespaces
+            .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+        self.format_version = StoreFormatVersion::V2;
+
+        // Commit the migration
+        self.commit("Migrate store from V1 (flat) to V2 (namespaced)")?;
+
+        Ok(MigrationReport {
+            keys_migrated,
+            namespaces_created: vec![DEFAULT_NAMESPACE.to_string()],
+            storage_version: StoreFormatVersion::V2,
+        })
+    }
+
+    /// Convenience method to merge with default IgnoreConflictsResolver.
+    pub fn merge_ignore_conflicts(
+        &mut self,
+        source_branch: &str,
+    ) -> Result<gix::ObjectId, GitKvError> {
+        self.merge(source_branch, &IgnoreConflictsResolver)
+    }
+
+    /// Check if a namespace changed between two commits.
+    pub fn namespace_changed(
+        &self,
+        prefix: &str,
+        commit_a: &str,
+        commit_b: &str,
+    ) -> Result<bool, GitKvError> {
+        let commit_id_a = self.resolve_commit(commit_a)?;
+        let commit_id_b = self.resolve_commit(commit_b)?;
+
+        let registry_a = self.load_registry_at_commit(&commit_id_a)?;
+        let registry_b = self.load_registry_at_commit(&commit_id_b)?;
+
+        let hash_a = registry_a.get(prefix).and_then(|e| e.root_hash.clone());
+        let hash_b = registry_b.get(prefix).and_then(|e| e.root_hash.clone());
+
+        Ok(hash_a != hash_b)
+    }
+
+    // -- Internal helpers ---------------------------------------------------
+
+    /// Resolve a reference (branch name, commit hex) to a commit ID.
+    fn resolve_commit(&self, reference: &str) -> Result<gix::ObjectId, GitKvError> {
+        // Try as branch
+        let branch_ref = format!("refs/heads/{reference}");
+        if let Ok(r) = self.inner.metadata.repo().refs.find(&branch_ref) {
+            if let Some(id) = r.target.try_id() {
+                return Ok(id.to_owned());
+            }
+        }
+        // Try as hex commit
+        gix::ObjectId::from_hex(reference.as_bytes())
+            .map_err(|e| GitKvError::GitObjectError(format!("Invalid reference: {e}")))
+    }
+
+    /// Get commit ID for a branch.
+    fn get_branch_commit(&self, branch: &str) -> Result<gix::ObjectId, GitKvError> {
+        let branch_ref = format!("refs/heads/{branch}");
+        match self.inner.metadata.repo().refs.find(&branch_ref) {
+            Ok(reference) => match reference.target.try_id() {
+                Some(id) => Ok(id.to_owned()),
+                None => Err(GitKvError::GitObjectError(format!(
+                    "Branch {branch} does not point to a commit"
+                ))),
+            },
+            Err(_) => Err(GitKvError::BranchNotFound(branch.to_string())),
+        }
+    }
+
+    /// Find the merge base (common ancestor) of two branches.
+    fn find_merge_base(&self, branch1: &str, branch2: &str) -> Result<gix::ObjectId, GitKvError> {
+        let commit1 = self.get_branch_commit(branch1)?;
+        let commit2 = self.get_branch_commit(branch2)?;
+
+        // Walk branch1 ancestors
+        let mut visited1 = HashSet::new();
+        let mut queue1 = std::collections::VecDeque::new();
+        queue1.push_back(commit1);
+        while let Some(cid) = queue1.pop_front() {
+            if !visited1.insert(cid) {
+                continue;
+            }
+            if let Ok(parents) = self.inner.metadata.commit_parents(&cid) {
+                for p in parents {
+                    if !visited1.contains(&p) {
+                        queue1.push_back(p);
+                    }
+                }
+            }
+        }
+
+        // Walk branch2 and find first common ancestor
+        let mut visited2 = HashSet::new();
+        let mut queue2 = std::collections::VecDeque::new();
+        queue2.push_back(commit2);
+        while let Some(cid) = queue2.pop_front() {
+            if !visited2.insert(cid) {
+                continue;
+            }
+            if visited1.contains(&cid) {
+                return Ok(cid);
+            }
+            if let Ok(parents) = self.inner.metadata.commit_parents(&cid) {
+                for p in parents {
+                    if !visited2.contains(&p) {
+                        queue2.push_back(p);
+                    }
+                }
+            }
+        }
+
+        Err(GitKvError::GitObjectError(
+            "No common ancestor found".to_string(),
+        ))
+    }
+
+    /// Load namespace registry from a specific git commit.
+    fn load_registry_at_commit(
+        &self,
+        commit_id: &gix::ObjectId,
+    ) -> Result<HashMap<String, NamespaceEntry<N>>, GitKvError> {
+        let dataset_dir = self.inner.tree.storage.dataset_dir();
+        let git_root = self
+            .inner
+            .metadata
+            .work_dir()
+            .or_else(|| VersionedKvStore::<N, GitNodeStorage<N>>::find_git_root(dataset_dir))
+            .ok_or_else(|| GitKvError::GitObjectError("Could not find git root".to_string()))?;
+
+        let dataset_relative = dataset_dir
+            .strip_prefix(&git_root)
+            .map_err(|e| GitKvError::GitObjectError(format!("Failed to get relative path: {e}")))?;
+
+        let rel_str = dataset_relative
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+
+        let registry_path = format!("{rel_str}/prolly_namespace_registry");
+
+        match self
+            .inner
+            .metadata
+            .read_file_at_commit(commit_id, &registry_path)
+        {
+            Ok(data) => {
+                let registry: HashMap<String, NamespaceEntry<N>> = serde_json::from_slice(&data)
+                    .map_err(|e| {
+                        GitKvError::GitObjectError(format!(
+                            "Failed to parse registry at commit: {e}"
+                        ))
+                    })?;
+                Ok(registry)
+            }
+            Err(_) => {
+                // No registry at this commit — probably V1 or initial commit
+                Ok(HashMap::new())
+            }
+        }
+    }
+
+    /// Build a snapshot of the current registry (from in-memory trees + saved registry).
+    fn current_registry_snapshot(&self) -> HashMap<String, NamespaceEntry<N>> {
+        let mut snapshot = self.registry.clone();
+        for (ns_name, tree) in &self.namespaces {
+            snapshot.insert(
+                ns_name.clone(),
+                NamespaceEntry {
+                    root_hash: tree.get_root_hash(),
+                    config: tree.config.clone(),
+                },
+            );
+        }
+        snapshot
+    }
+
+    /// Collect KV pairs for a namespace at a specific commit.
+    fn collect_ns_keys_at_commit(
+        &self,
+        ns_name: &str,
+        commit_id: &gix::ObjectId,
+        registry: &HashMap<String, NamespaceEntry<N>>,
+    ) -> Result<HashMap<Vec<u8>, Vec<u8>>, GitKvError> {
+        let entry = match registry.get(ns_name) {
+            Some(e) => e,
+            None => return Ok(HashMap::new()),
+        };
+
+        let root_hash = match &entry.root_hash {
+            Some(h) => h,
+            None => return Ok(HashMap::new()),
+        };
+
+        // Load hash mappings at this commit
+        let dataset_dir = self.inner.tree.storage.dataset_dir();
+        let git_root = self
+            .inner
+            .metadata
+            .work_dir()
+            .or_else(|| VersionedKvStore::<N, GitNodeStorage<N>>::find_git_root(dataset_dir))
+            .ok_or_else(|| GitKvError::GitObjectError("Could not find git root".to_string()))?;
+
+        let dataset_relative = dataset_dir
+            .strip_prefix(&git_root)
+            .map_err(|e| GitKvError::GitObjectError(format!("Failed to get relative path: {e}")))?;
+
+        let rel_str = dataset_relative
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+
+        // Load hash mappings — try namespace-specific first, then fall back to global
+        let ns_mapping_path = format!("{rel_str}/prolly_ns_hash_mappings");
+        let global_mapping_path = format!("{rel_str}/prolly_hash_mappings");
+
+        let mut hash_mappings: HashMap<ValueDigest<N>, gix::ObjectId> = HashMap::new();
+
+        // Load from both mapping files
+        for path in [&ns_mapping_path, &global_mapping_path] {
+            if let Ok(data) = self.inner.metadata.read_file_at_commit(commit_id, path) {
+                let mapping_str = String::from_utf8(data).unwrap_or_default();
+                for line in mapping_str.lines() {
+                    if let Some((hash_hex, object_hex)) = line.split_once(':') {
+                        if hash_hex.len() == N * 2 {
+                            let mut hash_bytes = Vec::new();
+                            for i in 0..N {
+                                if let Ok(byte) =
+                                    u8::from_str_radix(&hash_hex[i * 2..i * 2 + 2], 16)
+                                {
+                                    hash_bytes.push(byte);
+                                } else {
+                                    break;
+                                }
+                            }
+                            if hash_bytes.len() == N {
+                                if let Ok(object_id) =
+                                    gix::ObjectId::from_hex(object_hex.as_bytes())
+                                {
+                                    let hash = ValueDigest::raw_hash(&hash_bytes);
+                                    hash_mappings.insert(hash, object_id);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if hash_mappings.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        // Create temp storage and try to load tree
+        let temp_storage = GitNodeStorage::with_mappings(
+            self.inner.metadata.clone_repo(),
+            self.inner.tree.storage.dataset_dir().to_path_buf(),
+            hash_mappings,
+        )?;
+
+        let mut config = entry.config.clone();
+        config.root_hash = Some(root_hash.clone());
+
+        let tree = match ProllyTree::load_from_storage(temp_storage, config) {
+            Some(t) => t,
+            None => return Ok(HashMap::new()),
+        };
+
+        let mut kv = HashMap::new();
+        for key in tree.collect_keys() {
+            if let Some(node) = tree.find(&key) {
+                if let Some(idx) = node.keys.iter().position(|k| k == &key) {
+                    kv.insert(key, node.values[idx].clone());
+                }
+            }
+        }
+        Ok(kv)
+    }
+}
+
+// -- Helper on inner store for creating merge commits -----------------------
+
+impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> {
+    /// Create a merge commit for the namespaced store (public within crate).
+    pub(crate) fn create_merge_commit_for_namespaced(
+        &mut self,
+        source_branch: &str,
+    ) -> Result<gix::ObjectId, GitKvError> {
+        let dest_branch = self.current_branch.clone();
+        let message = format!("Merge branch '{source_branch}' into '{dest_branch}'");
+        self.create_merge_commit(&message, source_branch)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// InMemory backend
+// ---------------------------------------------------------------------------
+
+impl<const N: usize> NamespacedKvStore<N, InMemoryNodeStorage<N>, GitMetadataBackend> {
+    /// Commit staged changes (in-memory backend).
+    pub fn commit(&mut self, message: &str) -> Result<gix::ObjectId, GitKvError> {
+        self.commit_impl(message)
+    }
+
+    /// Initialize a new namespaced store with in-memory storage.
+    pub fn init<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        let inner = VersionedKvStore::<N, InMemoryNodeStorage<N>>::init(&path)?;
+
+        let mut store = NamespacedKvStore {
+            inner,
+            registry: HashMap::new(),
+            namespaces: HashMap::new(),
+            namespace_staging: HashMap::new(),
+            default_namespace: DEFAULT_NAMESPACE.to_string(),
+            dirty_namespaces: HashSet::new(),
+            format_version: StoreFormatVersion::V2,
+        };
+
+        let default_tree = ProllyTree::new(store.inner.tree.storage.clone(), TreeConfig::default());
+        store
+            .namespaces
+            .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+
+        store.commit("Initial namespaced store")?;
+        Ok(store)
+    }
+
+    /// Open an existing namespaced store with in-memory storage.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        let inner = VersionedKvStore::<N, InMemoryNodeStorage<N>>::open(&path)?;
+
+        let dataset_dir = inner
+            .dataset_dir
+            .as_ref()
+            .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".into()))?;
+        let format_version = Self::detect_format_version(dataset_dir);
+
+        let mut store = NamespacedKvStore {
+            inner,
+            registry: HashMap::new(),
+            namespaces: HashMap::new(),
+            namespace_staging: HashMap::new(),
+            default_namespace: DEFAULT_NAMESPACE.to_string(),
+            dirty_namespaces: HashSet::new(),
+            format_version: format_version.clone(),
+        };
+
+        match format_version {
+            StoreFormatVersion::V2 => {
+                store.load_namespace_registry()?;
+            }
+            StoreFormatVersion::V1 => {
+                let default_tree =
+                    ProllyTree::new(store.inner.tree.storage.clone(), TreeConfig::default());
+                store
+                    .namespaces
+                    .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+            }
+        }
+
+        Ok(store)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// File backend
+// ---------------------------------------------------------------------------
+
+impl<const N: usize> NamespacedKvStore<N, FileNodeStorage<N>, GitMetadataBackend> {
+    /// Commit staged changes (file backend).
+    pub fn commit(&mut self, message: &str) -> Result<gix::ObjectId, GitKvError> {
+        self.commit_impl(message)
+    }
+
+    /// Initialize a new namespaced store with file-based storage.
+    pub fn init<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        let inner = VersionedKvStore::<N, FileNodeStorage<N>>::init(&path)?;
+
+        let mut store = NamespacedKvStore {
+            inner,
+            registry: HashMap::new(),
+            namespaces: HashMap::new(),
+            namespace_staging: HashMap::new(),
+            default_namespace: DEFAULT_NAMESPACE.to_string(),
+            dirty_namespaces: HashSet::new(),
+            format_version: StoreFormatVersion::V2,
+        };
+
+        let default_tree = ProllyTree::new(store.inner.tree.storage.clone(), TreeConfig::default());
+        store
+            .namespaces
+            .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+
+        store.commit("Initial namespaced store")?;
+        Ok(store)
+    }
+
+    /// Open an existing namespaced store with file-based storage.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        let inner = VersionedKvStore::<N, FileNodeStorage<N>>::open(&path)?;
+
+        let dataset_dir = inner
+            .dataset_dir
+            .as_ref()
+            .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".into()))?;
+        let format_version = Self::detect_format_version(dataset_dir);
+
+        let mut store = NamespacedKvStore {
+            inner,
+            registry: HashMap::new(),
+            namespaces: HashMap::new(),
+            namespace_staging: HashMap::new(),
+            default_namespace: DEFAULT_NAMESPACE.to_string(),
+            dirty_namespaces: HashSet::new(),
+            format_version: format_version.clone(),
+        };
+
+        match format_version {
+            StoreFormatVersion::V2 => {
+                store.load_namespace_registry()?;
+            }
+            StoreFormatVersion::V1 => {
+                let default_tree =
+                    ProllyTree::new(store.inner.tree.storage.clone(), TreeConfig::default());
+                store
+                    .namespaces
+                    .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+            }
+        }
+
+        Ok(store)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ThreadSafeNamespacedKvStore implementation
+// ---------------------------------------------------------------------------
+
+impl<const N: usize, S: NodeStorage<N>, M: MetadataBackend> Clone
+    for ThreadSafeNamespacedKvStore<N, S, M>
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+// Send + Sync are auto-derived from Arc<Mutex<..>>
+
+impl<const N: usize, S: NodeStorage<N>, M: MetadataBackend> ThreadSafeNamespacedKvStore<N, S, M>
+where
+    VersionedKvStore<N, S, M>: TreeConfigSaver<N>,
+{
+    /// Wrap a `NamespacedKvStore` in a thread-safe handle.
+    pub fn new(store: NamespacedKvStore<N, S, M>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(store)),
+        }
+    }
+
+    /// Insert a key-value pair into a specific namespace.
+    pub fn ns_insert(
+        &self,
+        namespace: &str,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    ) -> Result<(), GitKvError> {
+        self.inner.lock().namespace(namespace).insert(key, value)
+    }
+
+    /// Get a value by key from a specific namespace.
+    pub fn ns_get(&self, namespace: &str, key: &[u8]) -> Option<Vec<u8>> {
+        self.inner.lock().namespace(namespace).get(key)
+    }
+
+    /// Delete a key from a specific namespace.
+    pub fn ns_delete(&self, namespace: &str, key: &[u8]) -> Result<bool, GitKvError> {
+        self.inner.lock().namespace(namespace).delete(key)
+    }
+
+    /// List all keys in a specific namespace.
+    pub fn ns_list_keys(&self, namespace: &str) -> Vec<Vec<u8>> {
+        self.inner.lock().namespace(namespace).list_keys()
+    }
+
+    /// List all namespace names.
+    pub fn list_namespaces(&self) -> Vec<String> {
+        self.inner.lock().list_namespaces()
+    }
+
+    /// Delete a namespace.
+    pub fn delete_namespace(&self, prefix: &str) -> Result<bool, GitKvError> {
+        self.inner.lock().delete_namespace(prefix)
+    }
+
+    /// Get namespace root hash.
+    pub fn get_namespace_root_hash(&self, prefix: &str) -> Option<ValueDigest<N>> {
+        self.inner.lock().get_namespace_root_hash(prefix)
+    }
+
+    /// Insert into default namespace.
+    pub fn insert(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), GitKvError> {
+        self.inner.lock().insert(key, value)
+    }
+
+    /// Get from default namespace.
+    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        self.inner.lock().get(key)
+    }
+
+    /// Delete from default namespace.
+    pub fn delete(&self, key: &[u8]) -> Result<bool, GitKvError> {
+        self.inner.lock().delete(key)
+    }
+
+    /// List keys in default namespace.
+    pub fn list_keys(&self) -> Vec<Vec<u8>> {
+        self.inner.lock().list_keys()
+    }
+
+    /// Create a new branch and switch to it.
+    pub fn create_branch(&self, name: &str) -> Result<(), GitKvError> {
+        self.inner.lock().create_branch(name)
+    }
+
+    /// Get current branch name.
+    pub fn current_branch(&self) -> String {
+        self.inner.lock().current_branch().to_string()
+    }
+
+    /// Get commit history.
+    pub fn log(&self) -> Result<Vec<CommitInfo>, GitKvError> {
+        self.inner.lock().log()
+    }
+}
+
+// Git-specific thread-safe methods
+impl<const N: usize> ThreadSafeNamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> {
+    /// Commit all staged changes (Git backend).
+    pub fn commit(&self, message: &str) -> Result<gix::ObjectId, GitKvError> {
+        self.inner.lock().commit(message)
+    }
+
+    /// Initialize a new thread-safe namespaced store with Git storage.
+    pub fn init<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        let store = GitNamespacedKvStore::init(path)?;
+        Ok(Self::new(store))
+    }
+
+    /// Open an existing thread-safe namespaced store with Git storage.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        let store = GitNamespacedKvStore::open(path)?;
+        Ok(Self::new(store))
+    }
+
+    /// Checkout a branch.
+    pub fn checkout(&self, branch_or_commit: &str) -> Result<(), GitKvError> {
+        self.inner.lock().checkout(branch_or_commit)
+    }
+
+    /// Merge with conflict resolution.
+    pub fn merge<R: ConflictResolver>(
+        &self,
+        source_branch: &str,
+        resolver: &R,
+    ) -> Result<gix::ObjectId, GitKvError> {
+        self.inner.lock().merge(source_branch, resolver)
+    }
+
+    /// Check if namespace changed between two commits.
+    pub fn namespace_changed(
+        &self,
+        prefix: &str,
+        commit_a: &str,
+        commit_b: &str,
+    ) -> Result<bool, GitKvError> {
+        self.inner
+            .lock()
+            .namespace_changed(prefix, commit_a, commit_b)
+    }
+}

--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -281,17 +281,18 @@ where
         if !self.namespaces.contains_key(prefix) {
             // Check if we have a registry entry to load from
             if let Some(entry) = self.registry.get(prefix) {
+                // Ensure root_hash is set on the config so load_from_storage
+                // can find the root node (entry.config.root_hash may be None
+                // even when entry.root_hash is Some).
+                let mut config = entry.config.clone();
+                config.root_hash = entry.root_hash.clone();
+
                 // Try loading from storage
                 let tree = if entry.root_hash.is_some() {
-                    ProllyTree::load_from_storage(
-                        self.inner.tree.storage.clone(),
-                        entry.config.clone(),
-                    )
-                    .unwrap_or_else(|| {
-                        ProllyTree::new(self.inner.tree.storage.clone(), entry.config.clone())
-                    })
+                    ProllyTree::load_from_storage(self.inner.tree.storage.clone(), config.clone())
+                        .unwrap_or_else(|| ProllyTree::new(self.inner.tree.storage.clone(), config))
                 } else {
-                    ProllyTree::new(self.inner.tree.storage.clone(), entry.config.clone())
+                    ProllyTree::new(self.inner.tree.storage.clone(), config)
                 };
                 self.namespaces.insert(prefix.to_string(), tree);
             } else {
@@ -734,8 +735,32 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
             // Also update the on-disk files to match the checked-out commit
             self.save_namespace_registry()?;
         } else {
-            // No registry at this commit — either V1 or pre-namespace commit
+            // No registry at this commit — either V1 or pre-namespace commit.
+            // Mirror `open()`'s V1 handling by exposing the checked-out inner
+            // flat tree through the default namespace view.
             self.format_version = StoreFormatVersion::V1;
+
+            let mut kv_pairs = Vec::new();
+            for key in self.inner.tree.collect_keys() {
+                if let Some(value) = self.inner.get(&key) {
+                    kv_pairs.push((key, value));
+                }
+            }
+            if !kv_pairs.is_empty() {
+                let mut default_tree =
+                    ProllyTree::new(self.inner.tree.storage.clone(), TreeConfig::default());
+                for (key, value) in kv_pairs {
+                    default_tree.insert(key, value);
+                }
+                default_tree.persist_root();
+                self.namespaces
+                    .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+            } else {
+                let default_tree =
+                    ProllyTree::new(self.inner.tree.storage.clone(), TreeConfig::default());
+                self.namespaces
+                    .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
+            }
         }
 
         Ok(())
@@ -817,7 +842,26 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
             let source_kv =
                 self.collect_ns_keys_at_commit(ns_name, &source_commit, &source_registry)?;
 
-            // Get dest KV from in-memory tree
+            // Get dest KV — ensure namespace is loaded first (namespaces are lazily
+            // loaded, so a namespace that exists in dest_registry but hasn't been
+            // accessed would appear empty if we only checked self.namespaces).
+            if !self.namespaces.contains_key(ns_name) {
+                if let Some(entry) = dest_registry.get(ns_name) {
+                    let mut config = entry.config.clone();
+                    config.root_hash = entry.root_hash.clone();
+                    let tree = if entry.root_hash.is_some() {
+                        ProllyTree::load_from_storage(
+                            self.inner.tree.storage.clone(),
+                            config.clone(),
+                        )
+                        .unwrap_or_else(|| ProllyTree::new(self.inner.tree.storage.clone(), config))
+                    } else {
+                        ProllyTree::new(self.inner.tree.storage.clone(), config)
+                    };
+                    self.namespaces.insert(ns_name.clone(), tree);
+                }
+            }
+
             let mut dest_kv = HashMap::new();
             if let Some(tree) = self.namespaces.get(ns_name) {
                 for key in tree.collect_keys() {
@@ -877,8 +921,41 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
                             merge_results.push(crate::diff::MergeResult::Conflict(conflict));
                         }
                     }
-                    (Some(_), None, Some(_)) => {
-                        merge_results.push(crate::diff::MergeResult::Removed(key.clone()));
+                    (Some(b), None, Some(d)) => {
+                        // Source deleted, dest may have modified
+                        if b == d {
+                            // Dest unchanged from base — safe to apply source deletion
+                            merge_results.push(crate::diff::MergeResult::Removed(key.clone()));
+                        } else {
+                            // Dest modified while source deleted — conflict
+                            let conflict = MergeConflict {
+                                key: key.clone(),
+                                base_value: Some(b.clone()),
+                                source_value: None,
+                                destination_value: Some(d.clone()),
+                            };
+                            merge_results.push(crate::diff::MergeResult::Conflict(conflict));
+                        }
+                    }
+                    (Some(b), Some(s), None) => {
+                        // Dest deleted, source may have modified
+                        if b == s {
+                            // Source unchanged from base — keep dest deletion (no-op)
+                            continue;
+                        } else {
+                            // Source modified while dest deleted — conflict
+                            let conflict = MergeConflict {
+                                key: key.clone(),
+                                base_value: Some(b.clone()),
+                                source_value: Some(s.clone()),
+                                destination_value: None,
+                            };
+                            merge_results.push(crate::diff::MergeResult::Conflict(conflict));
+                        }
+                    }
+                    (Some(_), None, None) => {
+                        // Both deleted — no-op
+                        continue;
                     }
                     _ => continue,
                 }
@@ -943,6 +1020,11 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
                 },
             );
         }
+
+        // Consolidate namespace hash mappings into inner storage before
+        // creating the merge commit, so prolly_hash_mappings includes all
+        // blob mappings needed to reload merged namespace roots.
+        self.merge_ns_hash_mappings_to_inner_git();
 
         self.inner.create_merge_commit_for_namespaced(source_branch)
     }

--- a/src/git/versioned_store/namespaced_tests.rs
+++ b/src/git/versioned_store/namespaced_tests.rs
@@ -1,0 +1,880 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#[cfg(test)]
+mod namespaced_tests {
+    use crate::git::versioned_store::namespaced::*;
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+
+    /// RAII guard that holds the global CWD mutex and restores the working
+    /// directory on drop. This prevents parallel tests from racing on CWD.
+    struct CwdGuard {
+        original: std::path::PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CwdGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let lock = crate::git::versioned_store::cwd_lock()
+                .lock()
+                .expect("CWD mutex poisoned");
+            let original = std::env::current_dir().expect("Failed to get current dir");
+            std::env::set_current_dir(path).expect("Failed to change directory");
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
+    /// Helper: create a temporary git repo with a dataset subdirectory.
+    fn setup_git_repo() -> (TempDir, std::path::PathBuf) {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let repo_path = temp_dir.path();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git init failed");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git config name failed");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git config email failed");
+
+        let dataset_path = repo_path.join("dataset");
+        std::fs::create_dir(&dataset_path).expect("Failed to create dataset dir");
+
+        (temp_dir, dataset_path)
+    }
+
+    // =====================================================================
+    // Basic namespace CRUD
+    // =====================================================================
+
+    #[test]
+    fn test_namespace_insert_get_delete() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Insert into "users" namespace
+        {
+            let mut ns = store.namespace("users");
+            ns.insert(b"user:1".to_vec(), b"Alice".to_vec())
+                .expect("insert failed");
+            ns.insert(b"user:2".to_vec(), b"Bob".to_vec())
+                .expect("insert failed");
+        }
+
+        // Read back
+        {
+            let ns = store.namespace("users");
+            assert_eq!(ns.get(b"user:1"), Some(b"Alice".to_vec()));
+            assert_eq!(ns.get(b"user:2"), Some(b"Bob".to_vec()));
+            assert_eq!(ns.get(b"user:3"), None);
+        }
+
+        // Delete
+        {
+            let mut ns = store.namespace("users");
+            assert!(ns.delete(b"user:1").expect("delete failed"));
+            assert!(!ns.delete(b"user:999").expect("delete failed"));
+        }
+
+        // Verify deletion
+        {
+            let ns = store.namespace("users");
+            assert_eq!(ns.get(b"user:1"), None);
+            assert_eq!(ns.get(b"user:2"), Some(b"Bob".to_vec()));
+        }
+    }
+
+    #[test]
+    fn test_namespace_list_keys() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        {
+            let mut ns = store.namespace("products");
+            ns.insert(b"prod:1".to_vec(), b"Laptop".to_vec()).unwrap();
+            ns.insert(b"prod:2".to_vec(), b"Mouse".to_vec()).unwrap();
+            ns.insert(b"prod:3".to_vec(), b"Keyboard".to_vec()).unwrap();
+        }
+
+        let keys = store.namespace("products").list_keys();
+        assert_eq!(keys.len(), 3);
+        assert!(keys.contains(&b"prod:1".to_vec()));
+        assert!(keys.contains(&b"prod:2".to_vec()));
+        assert!(keys.contains(&b"prod:3".to_vec()));
+    }
+
+    #[test]
+    fn test_multiple_namespaces_isolation() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Insert same key in two different namespaces
+        store
+            .namespace("ns_a")
+            .insert(b"key1".to_vec(), b"value_a".to_vec())
+            .unwrap();
+        store
+            .namespace("ns_b")
+            .insert(b"key1".to_vec(), b"value_b".to_vec())
+            .unwrap();
+
+        // Values are isolated
+        assert_eq!(
+            store.namespace("ns_a").get(b"key1"),
+            Some(b"value_a".to_vec())
+        );
+        assert_eq!(
+            store.namespace("ns_b").get(b"key1"),
+            Some(b"value_b".to_vec())
+        );
+
+        // Keys are isolated
+        let keys_a = store.namespace("ns_a").list_keys();
+        let keys_b = store.namespace("ns_b").list_keys();
+        assert_eq!(keys_a.len(), 1);
+        assert_eq!(keys_b.len(), 1);
+
+        // A third namespace sees nothing
+        assert!(store.namespace("ns_c").list_keys().is_empty());
+        assert_eq!(store.namespace("ns_c").get(b"key1"), None);
+    }
+
+    #[test]
+    fn test_default_namespace_backward_compat() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Use flat API (should route to "default" namespace)
+        store
+            .insert(b"flat_key".to_vec(), b"flat_value".to_vec())
+            .unwrap();
+        assert_eq!(store.get(b"flat_key"), Some(b"flat_value".to_vec()));
+
+        // Verify it's in the "default" namespace
+        assert_eq!(
+            store.namespace(DEFAULT_NAMESPACE).get(b"flat_key"),
+            Some(b"flat_value".to_vec())
+        );
+
+        // Keys from flat API appear in default namespace
+        let keys = store.namespace(DEFAULT_NAMESPACE).list_keys();
+        assert!(keys.contains(&b"flat_key".to_vec()));
+    }
+
+    // =====================================================================
+    // Registry operations
+    // =====================================================================
+
+    #[test]
+    fn test_list_namespaces() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Initially only "default"
+        let ns_list = store.list_namespaces();
+        assert!(ns_list.contains(&"default".to_string()));
+
+        // Create some namespaces
+        store
+            .namespace("users")
+            .insert(b"u1".to_vec(), b"Alice".to_vec())
+            .unwrap();
+        store
+            .namespace("products")
+            .insert(b"p1".to_vec(), b"Widget".to_vec())
+            .unwrap();
+        store
+            .namespace("orders")
+            .insert(b"o1".to_vec(), b"Order1".to_vec())
+            .unwrap();
+
+        let ns_list = store.list_namespaces();
+        assert_eq!(ns_list.len(), 4); // default + users + products + orders
+        assert!(ns_list.contains(&"users".to_string()));
+        assert!(ns_list.contains(&"products".to_string()));
+        assert!(ns_list.contains(&"orders".to_string()));
+        assert!(ns_list.contains(&"default".to_string()));
+    }
+
+    #[test]
+    fn test_delete_namespace() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        store
+            .namespace("temp")
+            .insert(b"key".to_vec(), b"value".to_vec())
+            .unwrap();
+        assert_eq!(store.list_namespaces().len(), 2); // default + temp
+
+        // Delete the namespace
+        assert!(store.delete_namespace("temp").unwrap());
+        assert!(!store.list_namespaces().contains(&"temp".to_string()));
+
+        // Deleting again returns false
+        assert!(!store.delete_namespace("temp").unwrap());
+
+        // Cannot delete default namespace
+        assert!(store.delete_namespace("default").is_err());
+    }
+
+    #[test]
+    fn test_get_namespace_root_hash() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Empty namespace has a root hash (empty tree hash)
+        let hash_before = store.get_namespace_root_hash("default");
+        assert!(hash_before.is_some());
+
+        // Insert data and verify hash changes
+        store
+            .namespace("default")
+            .insert(b"key".to_vec(), b"value".to_vec())
+            .unwrap();
+        store.commit("add key").unwrap();
+
+        let hash_after = store.get_namespace_root_hash("default");
+        assert!(hash_after.is_some());
+        // After insert + commit, the tree root hash should have changed
+        // (comparing pre-commit staging vs post-commit tree)
+
+        // Different namespaces have different root hashes
+        store
+            .namespace("other")
+            .insert(b"okey".to_vec(), b"oval".to_vec())
+            .unwrap();
+        store.commit("add other ns").unwrap();
+
+        let hash_default = store.get_namespace_root_hash("default");
+        let hash_other = store.get_namespace_root_hash("other");
+        assert!(hash_default.is_some());
+        assert!(hash_other.is_some());
+        assert_ne!(hash_default, hash_other);
+
+        // Non-existent namespace returns None
+        assert!(store.get_namespace_root_hash("nonexistent").is_none());
+    }
+
+    // =====================================================================
+    // Commit and persistence
+    // =====================================================================
+
+    #[test]
+    fn test_namespace_commit_and_reopen() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        // Create and populate
+        {
+            let mut store =
+                GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+            store
+                .namespace("users")
+                .insert(b"user:1".to_vec(), b"Alice".to_vec())
+                .unwrap();
+            store
+                .namespace("products")
+                .insert(b"prod:1".to_vec(), b"Widget".to_vec())
+                .unwrap();
+            store
+                .insert(b"default_key".to_vec(), b"default_val".to_vec())
+                .unwrap();
+
+            store.commit("Add data across namespaces").unwrap();
+        }
+
+        // Reopen and verify
+        {
+            let mut store =
+                GitNamespacedKvStore::<32>::open(&dataset_path).expect("Failed to open");
+
+            assert_eq!(store.format_version, StoreFormatVersion::V2);
+
+            // Check namespaces
+            let ns_list = store.list_namespaces();
+            assert!(ns_list.contains(&"users".to_string()));
+            assert!(ns_list.contains(&"products".to_string()));
+            assert!(ns_list.contains(&"default".to_string()));
+
+            // Check data
+            assert_eq!(
+                store.namespace("users").get(b"user:1"),
+                Some(b"Alice".to_vec())
+            );
+            assert_eq!(
+                store.namespace("products").get(b"prod:1"),
+                Some(b"Widget".to_vec())
+            );
+            assert_eq!(store.get(b"default_key"), Some(b"default_val".to_vec()));
+        }
+    }
+
+    #[test]
+    fn test_namespace_staging_isolation() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Stage changes in two namespaces without committing
+        store
+            .namespace("ns_a")
+            .insert(b"key".to_vec(), b"staged_a".to_vec())
+            .unwrap();
+        store
+            .namespace("ns_b")
+            .insert(b"key".to_vec(), b"staged_b".to_vec())
+            .unwrap();
+
+        // Both staging areas are independent
+        assert_eq!(
+            store.namespace("ns_a").get(b"key"),
+            Some(b"staged_a".to_vec())
+        );
+        assert_eq!(
+            store.namespace("ns_b").get(b"key"),
+            Some(b"staged_b".to_vec())
+        );
+
+        // Deleting from ns_a does not affect ns_b
+        store.namespace("ns_a").delete(b"key").unwrap();
+        assert_eq!(store.namespace("ns_a").get(b"key"), None);
+        assert_eq!(
+            store.namespace("ns_b").get(b"key"),
+            Some(b"staged_b".to_vec())
+        );
+    }
+
+    #[test]
+    fn test_namespace_dirty_tracking() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Insert into one namespace, commit
+        store
+            .namespace("ns_a")
+            .insert(b"k1".to_vec(), b"v1".to_vec())
+            .unwrap();
+        store.commit("add ns_a data").unwrap();
+
+        // Only ns_a should have been persisted with data
+        assert_eq!(store.namespace("ns_a").get(b"k1"), Some(b"v1".to_vec()));
+
+        // Now insert into ns_b and commit again
+        store
+            .namespace("ns_b")
+            .insert(b"k2".to_vec(), b"v2".to_vec())
+            .unwrap();
+        store.commit("add ns_b data").unwrap();
+
+        // Both namespaces have data
+        assert_eq!(store.namespace("ns_a").get(b"k1"), Some(b"v1".to_vec()));
+        assert_eq!(store.namespace("ns_b").get(b"k2"), Some(b"v2".to_vec()));
+    }
+
+    // =====================================================================
+    // Branching and checkout
+    // =====================================================================
+
+    #[test]
+    fn test_namespace_branch_checkout() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Add data on main
+        store
+            .namespace("users")
+            .insert(b"u1".to_vec(), b"Alice".to_vec())
+            .unwrap();
+        store.commit("main data").unwrap();
+
+        // Create branch and add more data
+        store.create_branch("feature").unwrap();
+        store
+            .namespace("users")
+            .insert(b"u2".to_vec(), b"Bob".to_vec())
+            .unwrap();
+        store.commit("feature data").unwrap();
+
+        // Verify feature branch has both
+        assert_eq!(store.namespace("users").get(b"u1"), Some(b"Alice".to_vec()));
+        assert_eq!(store.namespace("users").get(b"u2"), Some(b"Bob".to_vec()));
+
+        // Checkout main — should only have u1
+        store.checkout("main").unwrap();
+        assert_eq!(store.namespace("users").get(b"u1"), Some(b"Alice".to_vec()));
+        assert_eq!(store.namespace("users").get(b"u2"), None);
+
+        // Checkout feature again — has both
+        store.checkout("feature").unwrap();
+        assert_eq!(store.namespace("users").get(b"u2"), Some(b"Bob".to_vec()));
+    }
+
+    #[test]
+    fn test_namespace_across_branches() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Main: create ns_a
+        store
+            .namespace("ns_a")
+            .insert(b"key".to_vec(), b"main_a".to_vec())
+            .unwrap();
+        store.commit("main ns_a").unwrap();
+
+        // Feature: create ns_b
+        store.create_branch("feature").unwrap();
+        store
+            .namespace("ns_b")
+            .insert(b"key".to_vec(), b"feature_b".to_vec())
+            .unwrap();
+        store.commit("feature ns_b").unwrap();
+
+        // Feature has both namespaces
+        assert!(store.list_namespaces().contains(&"ns_a".to_string()));
+        assert!(store.list_namespaces().contains(&"ns_b".to_string()));
+
+        // Main only has ns_a
+        store.checkout("main").unwrap();
+        assert!(store.list_namespaces().contains(&"ns_a".to_string()));
+        // ns_b was created on feature branch, main shouldn't have it in registry
+    }
+
+    // =====================================================================
+    // Merge
+    // =====================================================================
+
+    #[test]
+    fn test_namespace_merge_no_conflict() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Main: add data to ns_a
+        store
+            .namespace("ns_a")
+            .insert(b"key_a".to_vec(), b"val_a".to_vec())
+            .unwrap();
+        store.commit("main: ns_a data").unwrap();
+
+        // Create feature branch, add data to ns_b (different namespace)
+        store.create_branch("feature").unwrap();
+        store
+            .namespace("ns_b")
+            .insert(b"key_b".to_vec(), b"val_b".to_vec())
+            .unwrap();
+        store.commit("feature: ns_b data").unwrap();
+
+        // Checkout main
+        store.checkout("main").unwrap();
+
+        // Merge feature into main
+        store.merge_ignore_conflicts("feature").unwrap();
+
+        // Main now has both namespaces' data
+        assert_eq!(
+            store.namespace("ns_a").get(b"key_a"),
+            Some(b"val_a".to_vec())
+        );
+        assert_eq!(
+            store.namespace("ns_b").get(b"key_b"),
+            Some(b"val_b".to_vec())
+        );
+    }
+
+    #[test]
+    fn test_namespace_merge_same_namespace() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Main: add initial data
+        store
+            .namespace("shared")
+            .insert(b"base_key".to_vec(), b"base_val".to_vec())
+            .unwrap();
+        store.commit("main: base data").unwrap();
+
+        // Create feature branch, add different key to same namespace
+        store.create_branch("feature").unwrap();
+        store
+            .namespace("shared")
+            .insert(b"feature_key".to_vec(), b"feature_val".to_vec())
+            .unwrap();
+        store.commit("feature: add feature_key").unwrap();
+
+        // Back to main, add another key
+        store.checkout("main").unwrap();
+        store
+            .namespace("shared")
+            .insert(b"main_key".to_vec(), b"main_val".to_vec())
+            .unwrap();
+        store.commit("main: add main_key").unwrap();
+
+        // Merge feature into main
+        store.merge_ignore_conflicts("feature").unwrap();
+
+        // All three keys should exist
+        assert_eq!(
+            store.namespace("shared").get(b"base_key"),
+            Some(b"base_val".to_vec())
+        );
+        assert_eq!(
+            store.namespace("shared").get(b"feature_key"),
+            Some(b"feature_val".to_vec())
+        );
+        assert_eq!(
+            store.namespace("shared").get(b"main_key"),
+            Some(b"main_val".to_vec())
+        );
+    }
+
+    // =====================================================================
+    // Change detection
+    // =====================================================================
+
+    #[test]
+    fn test_namespace_changed_detection() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Commit 1: add data to ns_a
+        store
+            .namespace("ns_a")
+            .insert(b"k1".to_vec(), b"v1".to_vec())
+            .unwrap();
+        let commit1 = store.commit("add ns_a").unwrap();
+        let commit1_hex = commit1.to_hex().to_string();
+
+        // Commit 2: add data to ns_b (ns_a unchanged)
+        store
+            .namespace("ns_b")
+            .insert(b"k2".to_vec(), b"v2".to_vec())
+            .unwrap();
+        let commit2 = store.commit("add ns_b").unwrap();
+        let commit2_hex = commit2.to_hex().to_string();
+
+        // ns_a did NOT change between commit1 and commit2
+        assert!(!store
+            .namespace_changed("ns_a", &commit1_hex, &commit2_hex)
+            .unwrap());
+
+        // ns_b DID change (didn't exist in commit1, exists in commit2)
+        assert!(store
+            .namespace_changed("ns_b", &commit1_hex, &commit2_hex)
+            .unwrap());
+
+        // Commit 3: modify ns_a
+        store
+            .namespace("ns_a")
+            .insert(b"k1".to_vec(), b"v1_updated".to_vec())
+            .unwrap();
+        let commit3 = store.commit("update ns_a").unwrap();
+        let commit3_hex = commit3.to_hex().to_string();
+
+        // ns_a changed between commit2 and commit3
+        assert!(store
+            .namespace_changed("ns_a", &commit2_hex, &commit3_hex)
+            .unwrap());
+
+        // ns_b did NOT change between commit2 and commit3
+        assert!(!store
+            .namespace_changed("ns_b", &commit2_hex, &commit3_hex)
+            .unwrap());
+    }
+
+    // =====================================================================
+    // Migration
+    // =====================================================================
+
+    #[test]
+    fn test_v1_to_v2_migration() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        // Create a V1 (flat) store using VersionedKvStore directly
+        {
+            use crate::git::versioned_store::GitVersionedKvStore;
+
+            let mut flat_store =
+                GitVersionedKvStore::<32>::init(&dataset_path).expect("Failed to init flat store");
+            flat_store
+                .insert(b"key1".to_vec(), b"value1".to_vec())
+                .unwrap();
+            flat_store
+                .insert(b"key2".to_vec(), b"value2".to_vec())
+                .unwrap();
+            flat_store.commit("v1 data").unwrap();
+        }
+
+        // Open with NamespacedKvStore (detects V1)
+        let mut store = GitNamespacedKvStore::<32>::open(&dataset_path).expect("Failed to open");
+        assert_eq!(store.format_version, StoreFormatVersion::V1);
+
+        // Data is accessible via default namespace
+        assert_eq!(store.get(b"key1"), Some(b"value1".to_vec()));
+        assert_eq!(store.get(b"key2"), Some(b"value2".to_vec()));
+
+        // Migrate to V2
+        let report = store.migrate_v1_to_v2().unwrap();
+        assert_eq!(report.keys_migrated, 2);
+        assert_eq!(report.storage_version, StoreFormatVersion::V2);
+        assert_eq!(store.format_version, StoreFormatVersion::V2);
+
+        // Data is still accessible
+        assert_eq!(store.get(b"key1"), Some(b"value1".to_vec()));
+        assert_eq!(store.get(b"key2"), Some(b"value2".to_vec()));
+
+        // Can now use namespace operations
+        store
+            .namespace("new_ns")
+            .insert(b"nk".to_vec(), b"nv".to_vec())
+            .unwrap();
+        store.commit("post-migration").unwrap();
+
+        assert!(store.list_namespaces().contains(&"new_ns".to_string()));
+    }
+
+    // =====================================================================
+    // Thread safety
+    // =====================================================================
+
+    #[test]
+    fn test_thread_safe_namespace_operations() {
+        let (temp_dir, dataset_path) = setup_git_repo();
+        let _cwd = CwdGuard::set(&dataset_path);
+
+        let store =
+            ThreadSafeGitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
+
+        // Insert from main thread
+        store
+            .ns_insert("users", b"u1".to_vec(), b"Alice".to_vec())
+            .unwrap();
+
+        // Read back
+        assert_eq!(store.ns_get("users", b"u1"), Some(b"Alice".to_vec()));
+
+        // List keys
+        let keys = store.ns_list_keys("users");
+        assert_eq!(keys.len(), 1);
+
+        // List namespaces
+        let ns_list = store.list_namespaces();
+        assert!(ns_list.contains(&"users".to_string()));
+
+        // Default namespace via flat API
+        store.insert(b"dk".to_vec(), b"dv".to_vec()).unwrap();
+        assert_eq!(store.get(b"dk"), Some(b"dv".to_vec()));
+
+        // Commit
+        store.commit("thread-safe test").unwrap();
+
+        // Verify after commit
+        assert_eq!(store.ns_get("users", b"u1"), Some(b"Alice".to_vec()));
+        assert_eq!(store.get(b"dk"), Some(b"dv".to_vec()));
+    }
+
+    // =====================================================================
+    // Comparison: prefix-based (old) vs subtree-based (new)
+    // =====================================================================
+
+    #[test]
+    fn test_namespace_vs_prefix_comparison() {
+        use crate::git::versioned_store::GitVersionedKvStore;
+        use std::time::Instant;
+
+        let num_namespaces = 5;
+        let keys_per_ns = 20;
+
+        // ── Setup: Old approach (prefix-based flat store) ──
+
+        let (_td_old, dataset_path_old) = setup_git_repo();
+        let _cwd_old = CwdGuard::set(&dataset_path_old);
+
+        let mut old_store =
+            GitVersionedKvStore::<32>::init(&dataset_path_old).expect("Failed to init old store");
+
+        for ns_idx in 0..num_namespaces {
+            for key_idx in 0..keys_per_ns {
+                let key = format!("/ns_{ns_idx}/key_{key_idx}").into_bytes();
+                let value = format!("value_{ns_idx}_{key_idx}").into_bytes();
+                old_store.insert(key, value).unwrap();
+            }
+        }
+        old_store.commit("old: populate").unwrap();
+
+        // ── Setup: New approach (subtree-based namespaced store) ──
+
+        let (_td_new, dataset_path_new) = setup_git_repo();
+        // Restore cwd first then set to new
+        drop(_cwd_old);
+        let _cwd_new = CwdGuard::set(&dataset_path_new);
+
+        let mut new_store =
+            GitNamespacedKvStore::<32>::init(&dataset_path_new).expect("Failed to init new store");
+
+        for ns_idx in 0..num_namespaces {
+            for key_idx in 0..keys_per_ns {
+                let ns_name = format!("ns_{ns_idx}");
+                let key = format!("key_{key_idx}").into_bytes();
+                let value = format!("value_{ns_idx}_{key_idx}").into_bytes();
+                new_store.namespace(&ns_name).insert(key, value).unwrap();
+            }
+        }
+        new_store.commit("new: populate").unwrap();
+
+        // ── Comparison 1: Namespace listing ──
+
+        // Old: must scan all keys and extract unique prefixes
+        let start_old = Instant::now();
+        let old_keys = old_store.list_keys();
+        let mut old_namespaces: HashSet<String> = HashSet::new();
+        for key in &old_keys {
+            let key_str = String::from_utf8_lossy(key);
+            if let Some(idx) = key_str[1..].find('/') {
+                old_namespaces.insert(key_str[1..idx + 1].to_string());
+            }
+        }
+        let old_ns_time = start_old.elapsed();
+
+        // New: direct registry lookup
+        let start_new = Instant::now();
+        let new_namespaces = new_store.list_namespaces();
+        let new_ns_time = start_new.elapsed();
+
+        assert_eq!(old_namespaces.len(), num_namespaces);
+        // new_namespaces includes "default" namespace
+        assert_eq!(new_namespaces.len(), num_namespaces + 1);
+
+        // ── Comparison 2: Namespace-scoped key listing ──
+
+        // Old: scan all keys, filter by prefix
+        let target_ns = "ns_2";
+        let prefix = format!("/{target_ns}/");
+
+        let start_old = Instant::now();
+        let old_ns_keys: Vec<_> = old_store
+            .list_keys()
+            .into_iter()
+            .filter(|k| String::from_utf8_lossy(k).starts_with(&prefix))
+            .collect();
+        let old_key_time = start_old.elapsed();
+
+        // New: direct namespace key listing
+        let start_new = Instant::now();
+        let new_ns_keys = new_store.namespace(target_ns).list_keys();
+        let new_key_time = start_new.elapsed();
+
+        assert_eq!(old_ns_keys.len(), keys_per_ns);
+        assert_eq!(new_ns_keys.len(), keys_per_ns);
+
+        // ── Comparison 3: Change detection ──
+
+        // Modify one namespace
+        let commit_before_hex = {
+            let log = new_store.log().unwrap();
+            log[0].id.to_hex().to_string()
+        };
+
+        new_store
+            .namespace("ns_0")
+            .insert(b"new_key".to_vec(), b"new_val".to_vec())
+            .unwrap();
+        let commit_after = new_store.commit("modify ns_0").unwrap();
+        let commit_after_hex = commit_after.to_hex().to_string();
+
+        // New: O(1) hash comparison per namespace
+        let start_new = Instant::now();
+        let ns0_changed = new_store
+            .namespace_changed("ns_0", &commit_before_hex, &commit_after_hex)
+            .unwrap();
+        let ns1_changed = new_store
+            .namespace_changed("ns_1", &commit_before_hex, &commit_after_hex)
+            .unwrap();
+        let new_change_time = start_new.elapsed();
+
+        assert!(ns0_changed, "ns_0 should have changed");
+        assert!(!ns1_changed, "ns_1 should NOT have changed");
+
+        // Old: must load full KV from both commits and compare
+        // (We don't measure this since VersionedKvStore doesn't have
+        //  a namespace_changed equivalent — it would require diff() + filtering)
+
+        // ── Print comparison results ──
+        println!("\n===== Namespace Approach Comparison =====");
+        println!(
+            "  Namespaces: {}, Keys per NS: {}",
+            num_namespaces, keys_per_ns
+        );
+        println!("  Total keys: {}", num_namespaces * keys_per_ns);
+        println!();
+        println!("  Namespace listing:");
+        println!("    Old (prefix scan):  {:?}", old_ns_time);
+        println!("    New (registry):     {:?}", new_ns_time);
+        println!();
+        println!("  Scoped key listing for '{target_ns}':");
+        println!("    Old (filter all):   {:?}", old_key_time);
+        println!("    New (subtree):      {:?}", new_key_time);
+        println!();
+        println!("  Change detection:");
+        println!("    Old: N/A (requires full diff + filter)");
+        println!("    New (hash compare): {:?}", new_change_time);
+        println!("=========================================\n");
+    }
+}

--- a/src/git/versioned_store/namespaced_tests.rs
+++ b/src/git/versioned_store/namespaced_tests.rs
@@ -78,7 +78,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_insert_get_delete() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -117,7 +117,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_list_keys() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -138,7 +138,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_multiple_namespaces_isolation() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -176,7 +176,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_default_namespace_backward_compat() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -204,7 +204,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_list_namespaces() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -237,7 +237,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_delete_namespace() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -261,7 +261,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_get_namespace_root_hash() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -305,7 +305,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_commit_and_reopen() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         // Create and populate
@@ -356,7 +356,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_staging_isolation() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -392,7 +392,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_dirty_tracking() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -425,7 +425,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_branch_checkout() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -461,7 +461,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_across_branches() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -497,7 +497,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_merge_no_conflict() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -536,7 +536,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_merge_same_namespace() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -588,7 +588,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_namespace_changed_detection() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let mut store = GitNamespacedKvStore::<32>::init(&dataset_path).expect("Failed to init");
@@ -644,7 +644,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_v1_to_v2_migration() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         // Create a V1 (flat) store using VersionedKvStore directly
@@ -696,7 +696,7 @@ mod namespaced_tests {
 
     #[test]
     fn test_thread_safe_namespace_operations() {
-        let (temp_dir, dataset_path) = setup_git_repo();
+        let (_temp_dir, dataset_path) = setup_git_repo();
         let _cwd = CwdGuard::set(&dataset_path);
 
         let store =

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -17,16 +17,24 @@ mod proof_tests {
     use crate::git::versioned_store::{GitVersionedKvStore, HistoricalAccess};
     use tempfile::TempDir;
 
-    /// RAII guard that restores the working directory on drop (even on panic).
+    /// RAII guard that holds the global CWD mutex and restores the working
+    /// directory on drop. This prevents parallel tests from racing on CWD.
     struct CwdGuard {
         original: std::path::PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
     }
 
     impl CwdGuard {
         fn set(path: &std::path::Path) -> Self {
+            let lock = crate::git::versioned_store::cwd_lock()
+                .lock()
+                .expect("CWD mutex poisoned");
             let original = std::env::current_dir().expect("Failed to get current dir");
             std::env::set_current_dir(path).expect("Failed to change directory");
-            Self { original }
+            Self {
+                original,
+                _lock: lock,
+            }
         }
     }
 
@@ -218,6 +226,33 @@ mod tests {
     };
     use tempfile::TempDir;
 
+    /// RAII guard that holds the global CWD mutex and restores the working
+    /// directory on drop. This prevents parallel tests from racing on CWD.
+    struct CwdGuard {
+        original: std::path::PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CwdGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let lock = crate::git::versioned_store::cwd_lock()
+                .lock()
+                .expect("CWD mutex poisoned");
+            let original = std::env::current_dir().expect("Failed to get current dir");
+            std::env::set_current_dir(path).expect("Failed to change directory");
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
     #[test]
     fn test_versioned_store_init() {
         let temp_dir = TempDir::new().unwrap();
@@ -226,6 +261,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
         let store = GitVersionedKvStore::<32>::init(&dataset_dir);
         assert!(store.is_ok());
     }
@@ -238,6 +274,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
         // Test insert and get
@@ -263,6 +300,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
         // Stage changes
@@ -293,6 +331,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -346,6 +385,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -416,6 +456,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -468,6 +509,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         // First init - creates new store
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
@@ -508,6 +550,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -534,6 +577,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = InMemoryVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -578,6 +622,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -643,6 +688,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -680,6 +726,7 @@ mod tests {
         // Create subdirectory for dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         // Test InMemory storage
         {
@@ -770,6 +817,7 @@ mod tests {
         gix::init(temp_dir.path()).unwrap();
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -1003,6 +1051,7 @@ mod tests {
         gix::init(temp_dir.path()).unwrap();
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -1100,6 +1149,7 @@ mod tests {
         gix::init(temp_dir.path()).unwrap();
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -1224,6 +1274,7 @@ mod tests {
         gix::init(temp_dir.path()).unwrap();
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -1317,6 +1368,7 @@ mod tests {
         // Create a subdirectory for the dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let store = ThreadSafeGitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -1349,6 +1401,7 @@ mod tests {
         // Create a subdirectory for the dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let store = Arc::new(ThreadSafeGitVersionedKvStore::<32>::init(&dataset_dir).unwrap());
 
@@ -1406,6 +1459,7 @@ mod tests {
         // Create a subdirectory for the dataset
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 
@@ -1505,6 +1559,7 @@ mod tests {
 
         let dataset_dir = temp_dir.path().join("dataset");
         std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
 
         let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -1087,6 +1087,33 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// RAII guard that holds the global CWD mutex and restores the working
+    /// directory on drop. Prevents parallel tests from racing on CWD.
+    struct CwdGuard {
+        original: std::path::PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl CwdGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let lock = crate::git::versioned_store::cwd_lock()
+                .lock()
+                .expect("CWD mutex poisoned");
+            let original = std::env::current_dir().expect("Failed to get current dir");
+            std::env::set_current_dir(path).expect("Failed to change directory");
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
     /// Helper function to initialize a Git repository properly for testing
     fn init_test_git_repo(repo_path: &std::path::Path) {
         use gix::prelude::*;
@@ -1155,6 +1182,7 @@ mod tests {
     fn test_worktree_manager_creation() {
         let temp_dir = TempDir::new().unwrap();
         let repo_path = temp_dir.path();
+        let _cwd = CwdGuard::set(repo_path);
 
         // Initialize a git repository properly
         init_test_git_repo(repo_path);
@@ -1171,6 +1199,7 @@ mod tests {
     fn test_add_worktree() {
         let temp_dir = TempDir::new().unwrap();
         let repo_path = temp_dir.path();
+        let _cwd = CwdGuard::set(repo_path);
 
         // Initialize a git repository properly
         init_test_git_repo(repo_path);
@@ -1193,6 +1222,7 @@ mod tests {
     fn test_worktree_locking() {
         let temp_dir = TempDir::new().unwrap();
         let repo_path = temp_dir.path();
+        let _cwd = CwdGuard::set(repo_path);
 
         // Initialize a git repository properly
         init_test_git_repo(repo_path);
@@ -1222,6 +1252,7 @@ mod tests {
     fn test_worktree_concept_validation() {
         let temp_dir = TempDir::new().unwrap();
         let repo_path = temp_dir.path();
+        let _cwd = CwdGuard::set(repo_path);
 
         // Initialize repository properly
         init_test_git_repo(repo_path);
@@ -1274,6 +1305,7 @@ mod tests {
     fn test_worktree_merge_functionality() {
         let temp_dir = TempDir::new().unwrap();
         let repo_path = temp_dir.path();
+        let _cwd = CwdGuard::set(repo_path);
 
         // Initialize repository properly
         init_test_git_repo(repo_path);
@@ -1366,6 +1398,7 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
         let repo_path = temp_dir.path();
+        let _cwd = CwdGuard::set(repo_path);
 
         // Initialize repository properly
         init_test_git_repo(repo_path);
@@ -1484,6 +1517,7 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
         let repo_path = temp_dir.path();
+        let _cwd = CwdGuard::set(repo_path);
 
         // Initialize repository properly
         init_test_git_repo(repo_path);

--- a/src/python.rs
+++ b/src/python.rs
@@ -25,8 +25,8 @@ use crate::{
     git::{
         types::{DiffOperation, StorageBackend},
         versioned_store::{
-            FileVersionedKvStore, GitVersionedKvStore, HistoricalAccess, HistoricalCommitAccess,
-            InMemoryVersionedKvStore, ThreadSafeGitVersionedKvStore,
+            FileVersionedKvStore, GitNamespacedKvStore, GitVersionedKvStore, HistoricalAccess,
+            HistoricalCommitAccess, InMemoryVersionedKvStore, ThreadSafeGitVersionedKvStore,
         },
     },
     proof::Proof,
@@ -1867,6 +1867,252 @@ fn sql_value_to_json(value: &SqlValue) -> serde_json::Value {
     }
 }
 
+// ---------------------------------------------------------------------------
+// NamespacedKvStore Python bindings
+// ---------------------------------------------------------------------------
+
+/// Python wrapper for the namespace-aware versioned key-value store.
+///
+/// Each namespace is backed by its own ProllyTree subtree, enabling O(1) change
+/// detection, efficient namespace-scoped operations, and clean isolation.
+#[pyclass(name = "NamespacedKvStore")]
+struct PyNamespacedKvStore {
+    inner: Arc<Mutex<GitNamespacedKvStore<32>>>,
+}
+
+#[pymethods]
+impl PyNamespacedKvStore {
+    /// Create a new NamespacedKvStore (initializes a new Git repository dataset).
+    #[new]
+    fn new(path: String) -> PyResult<Self> {
+        let store = GitNamespacedKvStore::<32>::init(&path).map_err(|e| {
+            PyValueError::new_err(format!("Failed to initialize NamespacedKvStore: {e}"))
+        })?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(store)),
+        })
+    }
+
+    /// Open an existing NamespacedKvStore (auto-detects V1/V2 format).
+    #[staticmethod]
+    fn open(path: String) -> PyResult<Self> {
+        let store = GitNamespacedKvStore::<32>::open(&path)
+            .map_err(|e| PyValueError::new_err(format!("Failed to open NamespacedKvStore: {e}")))?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(store)),
+        })
+    }
+
+    // -- Namespace-scoped operations --
+
+    /// Insert a key-value pair into a specific namespace.
+    fn ns_insert(
+        &self,
+        namespace: &str,
+        key: &Bound<'_, PyBytes>,
+        value: &Bound<'_, PyBytes>,
+    ) -> PyResult<()> {
+        let mut store = self.inner.lock();
+        store
+            .namespace(namespace)
+            .insert(key.as_bytes().to_vec(), value.as_bytes().to_vec())
+            .map_err(|e| PyValueError::new_err(format!("Insert failed: {e}")))
+    }
+
+    /// Get a value by key from a specific namespace.
+    fn ns_get<'py>(
+        &self,
+        py: Python<'py>,
+        namespace: &str,
+        key: &Bound<'py, PyBytes>,
+    ) -> PyResult<Option<Py<PyBytes>>> {
+        let mut store = self.inner.lock();
+        Ok(store
+            .namespace(namespace)
+            .get(key.as_bytes())
+            .map(|v| PyBytes::new_bound(py, &v).into()))
+    }
+
+    /// Delete a key from a specific namespace.
+    fn ns_delete(&self, namespace: &str, key: &Bound<'_, PyBytes>) -> PyResult<bool> {
+        let mut store = self.inner.lock();
+        store
+            .namespace(namespace)
+            .delete(key.as_bytes())
+            .map_err(|e| PyValueError::new_err(format!("Delete failed: {e}")))
+    }
+
+    /// List all keys in a specific namespace.
+    fn ns_list_keys<'py>(&self, py: Python<'py>, namespace: &str) -> PyResult<Py<PyList>> {
+        let mut store = self.inner.lock();
+        let keys = store.namespace(namespace).list_keys();
+        let py_keys: Vec<Py<PyBytes>> = keys
+            .iter()
+            .map(|k| PyBytes::new_bound(py, k).into())
+            .collect();
+        Ok(PyList::new_bound(py, &py_keys).into())
+    }
+
+    // -- Registry operations --
+
+    /// List all namespace names.
+    fn list_namespaces(&self) -> Vec<String> {
+        self.inner.lock().list_namespaces()
+    }
+
+    /// Delete an entire namespace.
+    fn delete_namespace(&self, namespace: &str) -> PyResult<bool> {
+        self.inner
+            .lock()
+            .delete_namespace(namespace)
+            .map_err(|e| PyValueError::new_err(format!("Delete namespace failed: {e}")))
+    }
+
+    /// Get the root hash for a namespace (O(1) lookup).
+    fn get_namespace_root_hash<'py>(
+        &self,
+        py: Python<'py>,
+        namespace: &str,
+    ) -> Option<Py<PyBytes>> {
+        self.inner
+            .lock()
+            .get_namespace_root_hash(namespace)
+            .map(|h| PyBytes::new_bound(py, h.as_bytes()).into())
+    }
+
+    /// Check if a namespace changed between two commits.
+    fn namespace_changed(&self, namespace: &str, commit_a: &str, commit_b: &str) -> PyResult<bool> {
+        self.inner
+            .lock()
+            .namespace_changed(namespace, commit_a, commit_b)
+            .map_err(|e| PyValueError::new_err(format!("namespace_changed failed: {e}")))
+    }
+
+    // -- Backward-compatible flat API (default namespace) --
+
+    /// Insert into the default namespace.
+    fn insert(&self, key: &Bound<'_, PyBytes>, value: &Bound<'_, PyBytes>) -> PyResult<()> {
+        self.inner
+            .lock()
+            .insert(key.as_bytes().to_vec(), value.as_bytes().to_vec())
+            .map_err(|e| PyValueError::new_err(format!("Insert failed: {e}")))
+    }
+
+    /// Get from the default namespace.
+    fn get<'py>(
+        &self,
+        py: Python<'py>,
+        key: &Bound<'py, PyBytes>,
+    ) -> PyResult<Option<Py<PyBytes>>> {
+        Ok(self
+            .inner
+            .lock()
+            .get(key.as_bytes())
+            .map(|v| PyBytes::new_bound(py, &v).into()))
+    }
+
+    /// Delete from the default namespace.
+    fn delete(&self, key: &Bound<'_, PyBytes>) -> PyResult<bool> {
+        self.inner
+            .lock()
+            .delete(key.as_bytes())
+            .map_err(|e| PyValueError::new_err(format!("Delete failed: {e}")))
+    }
+
+    /// List keys in the default namespace.
+    fn list_keys<'py>(&self, py: Python<'py>) -> PyResult<Py<PyList>> {
+        let keys = self.inner.lock().list_keys();
+        let py_keys: Vec<Py<PyBytes>> = keys
+            .iter()
+            .map(|k| PyBytes::new_bound(py, k).into())
+            .collect();
+        Ok(PyList::new_bound(py, &py_keys).into())
+    }
+
+    // -- Git operations --
+
+    /// Commit all staged changes across all namespaces.
+    #[pyo3(signature = (message=None))]
+    fn commit(&self, message: Option<&str>) -> PyResult<String> {
+        let msg = message.unwrap_or("commit");
+        self.inner
+            .lock()
+            .commit(msg)
+            .map(|id| id.to_hex().to_string())
+            .map_err(|e| PyValueError::new_err(format!("Commit failed: {e}")))
+    }
+
+    /// Checkout a branch or commit.
+    fn checkout(&self, branch_or_commit: &str) -> PyResult<()> {
+        self.inner
+            .lock()
+            .checkout(branch_or_commit)
+            .map_err(|e| PyValueError::new_err(format!("Checkout failed: {e}")))
+    }
+
+    /// Create a new branch and switch to it.
+    fn branch(&self, name: &str) -> PyResult<()> {
+        self.inner
+            .lock()
+            .create_branch(name)
+            .map_err(|e| PyValueError::new_err(format!("Branch failed: {e}")))
+    }
+
+    /// Get current branch name.
+    #[getter]
+    fn current_branch(&self) -> String {
+        self.inner.lock().current_branch().to_string()
+    }
+
+    /// Get commit history.
+    fn log(&self) -> PyResult<Vec<HashMap<String, String>>> {
+        let history = self
+            .inner
+            .lock()
+            .log()
+            .map_err(|e| PyValueError::new_err(format!("Log failed: {e}")))?;
+        Ok(history
+            .into_iter()
+            .map(|c| {
+                let mut m = HashMap::new();
+                m.insert("id".to_string(), c.id.to_hex().to_string());
+                m.insert("message".to_string(), c.message);
+                m.insert("author".to_string(), c.author);
+                m.insert("timestamp".to_string(), c.timestamp.to_string());
+                m
+            })
+            .collect())
+    }
+
+    /// Migrate a V1 (flat) store to V2 (namespaced) format.
+    fn migrate_v1_to_v2(&self) -> PyResult<HashMap<String, String>> {
+        let report = self
+            .inner
+            .lock()
+            .migrate_v1_to_v2()
+            .map_err(|e| PyValueError::new_err(format!("Migration failed: {e}")))?;
+        let mut m = HashMap::new();
+        m.insert(
+            "keys_migrated".to_string(),
+            report.keys_migrated.to_string(),
+        );
+        m.insert(
+            "namespaces_created".to_string(),
+            report.namespaces_created.join(", "),
+        );
+        Ok(m)
+    }
+
+    fn __repr__(&self) -> String {
+        let store = self.inner.lock();
+        format!(
+            "NamespacedKvStore(namespaces={}, branch='{}')",
+            store.list_namespaces().len(),
+            store.current_branch()
+        )
+    }
+}
+
 #[pymodule]
 fn prollytree(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTreeConfig>()?;
@@ -1877,6 +2123,8 @@ fn prollytree(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDiffOperation>()?;
     m.add_class::<PyKvDiff>()?;
     m.add_class::<PyVersionedKvStore>()?;
+    #[cfg(feature = "git")]
+    m.add_class::<PyNamespacedKvStore>()?;
     #[cfg(feature = "git")]
     m.add_class::<PyWorktreeManager>()?;
     #[cfg(feature = "git")]

--- a/src/storage/git.rs
+++ b/src/storage/git.rs
@@ -70,6 +70,16 @@ impl<const N: usize> GitNodeStorage<N> {
         self.hash_to_object_id.lock().clone()
     }
 
+    /// Merge additional hash mappings into this storage instance.
+    ///
+    /// This is used by [`NamespacedKvStore`] to consolidate hash mappings from
+    /// namespace subtrees into the main storage before committing, so that
+    /// `save_tree_config_to_git` writes all mappings.
+    pub fn merge_hash_mappings(&self, other_mappings: HashMap<ValueDigest<N>, gix::ObjectId>) {
+        let mut map = self.hash_to_object_id.lock();
+        map.extend(other_mappings);
+    }
+
     /// Create a new GitNodeStorage instance
     pub fn new(
         repository: gix::Repository,


### PR DESCRIPTION
Adds a new namespaced Git-backed KV store variant that stores each namespace in its own ProllyTree subtree (with a persisted namespace registry), plus Python bindings and expanded test coverage.

Changes:

- Introduces NamespacedKvStore / GitNamespacedKvStore with per-namespace subtrees, registry persistence, namespace-aware branching/checkout/merge, and V1→V2 migration support.
- Adds Python bindings for the namespaced store (NamespacedKvStore class) with namespace-scoped APIs and backward-compatible flat APIs.
- Hardens Git-related tests against flaky parallel execution by serializing process-wide CWD changes.