### PR TITLE
Fix GH-161 and GH-162

### DIFF
--- a/src/git/versioned_store/backends.rs
+++ b/src/git/versioned_store/backends.rs
@@ -64,13 +64,23 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         std::fs::write(&config_path, config_json)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to write config file: {e}")))?;
 
-        // Get hash mappings from storage and save them
+        // Get hash mappings from storage and save them, sorted by hash bytes so that
+        // the on-disk file is byte-deterministic for a given set of mappings. Without
+        // this, HashMap iteration order varies between processes and `git status`
+        // spuriously reports `prolly_hash_mappings` as modified after checkout /
+        // reload even though the logical mapping set is unchanged (see GH-161).
         let mappings = self.tree.storage.get_hash_mappings();
+        let mut entries: Vec<(String, String)> = mappings
+            .iter()
+            .map(|(hash, object_id)| {
+                let hash_hex: String = hash.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
+                (hash_hex, object_id.to_hex().to_string())
+            })
+            .collect();
+        entries.sort();
         let mut mappings_content = String::new();
-        for (hash, object_id) in mappings {
-            // Convert hash bytes to hex manually
-            let hash_hex: String = hash.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
-            mappings_content.push_str(&format!("{hash_hex}:{object_id}\n"));
+        for (hash_hex, object_hex) in &entries {
+            mappings_content.push_str(&format!("{hash_hex}:{object_hex}\n"));
         }
 
         // Write mappings to the dataset directory
@@ -113,6 +123,10 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
                 return Err(GitKvError::BranchNotFound(branch_or_commit.to_string()));
             }
         }
+
+        // Sync working tree and index under the dataset dir to match the new HEAD
+        // so `git status` is clean afterward (see GH-161).
+        self.sync_working_tree_to_head()?;
 
         // Git-specific: Reload the tree from the HEAD commit of the target branch
         self.reload_tree_from_head()?;

--- a/src/git/versioned_store/history.rs
+++ b/src/git/versioned_store/history.rs
@@ -331,8 +331,73 @@ where
         // Update HEAD to point to the new branch
         self.metadata.update_head(branch_or_commit)?;
 
+        // Sync git's index and working tree under the dataset directory to match
+        // the new HEAD. Without this, prolly's own committed files
+        // (prolly_config_tree_config, prolly_hash_mappings, ...) retain the previous
+        // branch's content on disk and `git status` reports them as modified —
+        // confusing any outside tool working against the repo (see GH-161). Doing
+        // the sync before `reload_tree_from_head_generic` also makes the in-memory
+        // tree consistent with what any subsequent git-level reader would see.
+        self.sync_working_tree_to_head()?;
+
         // Reload the tree from the HEAD commit
         self.reload_tree_from_head_generic()?;
+
+        Ok(())
+    }
+
+    /// Restore the working tree and index under the dataset directory to match the
+    /// current HEAD commit. This is the moral equivalent of `git checkout HEAD -- .`
+    /// scoped to `dataset_dir`, so non-prolly files living outside the dataset are
+    /// left untouched. Used by `checkout_generic` (GH-161).
+    pub(super) fn sync_working_tree_to_head(&self) -> Result<(), GitKvError> {
+        let dataset_dir = self
+            .dataset_dir
+            .as_ref()
+            .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".into()))?;
+        let git_root = self
+            .metadata
+            .work_dir()
+            .or_else(|| Self::find_git_root(dataset_dir))
+            .ok_or_else(|| GitKvError::GitObjectError("Could not find git root".into()))?;
+
+        let relative = dataset_dir.strip_prefix(&git_root).map_err(|e| {
+            GitKvError::GitObjectError(format!("dataset_dir not under git_root: {e}"))
+        })?;
+        // `.` when the dataset is the repo root; otherwise the relative path.
+        let relative_str = if relative.as_os_str().is_empty() {
+            ".".to_string()
+        } else {
+            relative.to_string_lossy().replace('\\', "/")
+        };
+
+        // `git checkout HEAD -- <path>` rewrites both the index and the working tree
+        // under <path> to match HEAD. If HEAD doesn't track a file that exists in
+        // the working tree, git leaves it alone — so user-owned untracked files in
+        // the dataset directory are preserved. Unlike `git reset --hard`, this does
+        // not touch anything outside the given pathspec.
+        let output = std::process::Command::new("git")
+            .args(["checkout", "HEAD", "--", &relative_str])
+            .current_dir(&git_root)
+            .output()
+            .map_err(|e| {
+                GitKvError::GitObjectError(format!("Failed to run `git checkout HEAD -- .`: {e}"))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // On an empty / non-existent path in HEAD, git complains but we can
+            // safely treat that as a no-op (e.g. first checkout on a fresh repo).
+            if stderr.contains("did not match any file")
+                || stderr.contains("pathspec")
+                || stderr.contains("error: pathspec")
+            {
+                return Ok(());
+            }
+            return Err(GitKvError::GitObjectError(format!(
+                "`git checkout HEAD -- {relative_str}` failed: {stderr}"
+            )));
+        }
 
         Ok(())
     }

--- a/src/git/versioned_store/history.rs
+++ b/src/git/versioned_store/history.rs
@@ -289,8 +289,12 @@ where
         // Get the current HEAD commit
         let head_object_id = self.metadata.head_commit_id()?;
 
-        // Load all key-value pairs from the HEAD commit using HistoricalAccess
-        let keys_at_head = self.collect_keys_from_commit_generic(&head_object_id)?;
+        // Load keys via HistoricalAccess::get_keys_at_ref so the Git backend reads
+        // the per-commit `prolly_hash_mappings` blob (via `collect_keys_at_commit`)
+        // rather than looking up the commit's root hash in the current in-memory
+        // mappings, which can be narrower than the commit's view after a
+        // `git reset` / working-tree switch (see GH-162).
+        let keys_at_head = self.get_keys_at_ref(&head_object_id.to_hex().to_string())?;
 
         // Get the config from the commit
         let config = self.read_tree_config_from_commit(&head_object_id)?;
@@ -309,18 +313,6 @@ where
         }
 
         Ok(())
-    }
-
-    /// Collect all key-value pairs from a specific commit (generic version)
-    pub(super) fn collect_keys_from_commit_generic(
-        &self,
-        commit_id: &gix::ObjectId,
-    ) -> Result<HashMap<Vec<u8>, Vec<u8>>, GitKvError> {
-        // Read the tree config from the commit
-        let tree_config = self.read_tree_config_from_commit(commit_id)?;
-
-        // Use the generic collect_keys_from_config which works for all storage types
-        self.collect_keys_from_config(&tree_config)
     }
 
     /// Switch to a different branch or commit (generic version for all backends)
@@ -359,10 +351,19 @@ where
         // Find common base commit
         let base_commit = self.find_merge_base_generic(&dest_branch, source_branch)?;
 
-        // Get key-value data from each state
-        let base_kv = self.collect_keys_from_commit_generic(&base_commit)?;
+        // Get key-value data from each state via HistoricalAccess::get_keys_at_ref.
+        //
+        // The Git backend's specialization reads the per-commit `prolly_hash_mappings`
+        // blob out of each commit's tree (see `collect_keys_at_commit`), so it works
+        // even when the working-tree mappings file was narrowed by `git reset` /
+        // `git checkout` back to a single branch's view (see GH-162). Using the
+        // generic `collect_keys_from_config` path here would look the commit's root
+        // hash up in the *current in-memory* mappings and spuriously return an empty
+        // set for roots that only existed on the other branch.
         let source_commit = self.get_branch_commit_generic(source_branch)?;
-        let source_kv = self.collect_keys_from_commit_generic(&source_commit)?;
+        let base_kv = self.get_keys_at_ref(&base_commit.to_hex().to_string())?;
+        let source_kv = self.get_keys_at_ref(&source_commit.to_hex().to_string())?;
+
         let mut dest_kv = HashMap::new();
 
         for key in self.tree.collect_keys() {

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -1989,6 +1989,76 @@ mod tests {
         );
     }
 
+    // Regression for issue #161: `checkout` left `git status` dirty on prolly's own
+    // files (prolly_config_tree_config, prolly_hash_mappings) because it only
+    // updated .git/HEAD without syncing the working tree / index, and because the
+    // per-insert append to `prolly_hash_mappings` in unsorted order drifted against
+    // the sorted commit-time snapshot. After the fix, `git status` must be clean
+    // after any checkout regardless of how many branches have been touched.
+    #[test]
+    fn test_git_checkout_leaves_working_tree_clean() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_root = temp_dir.path();
+
+        std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(repo_root)
+            .output()
+            .expect("git init failed");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo_root)
+            .output()
+            .expect("git config name failed");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo_root)
+            .output()
+            .expect("git config email failed");
+
+        let dataset_dir = repo_root.join("data");
+        std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+
+        store.insert(b"A".to_vec(), b"1".to_vec()).unwrap();
+        store.insert(b"B".to_vec(), b"2".to_vec()).unwrap();
+        store.commit("seed").unwrap();
+
+        store.create_branch("feat").unwrap();
+        store.checkout("feat").unwrap();
+        store.insert(b"C".to_vec(), b"3".to_vec()).unwrap();
+        store.commit("add C on feat").unwrap();
+
+        store.checkout("main").unwrap();
+
+        let status = std::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(repo_root)
+            .output()
+            .expect("git status failed");
+        let status_stdout = String::from_utf8_lossy(&status.stdout);
+        assert!(
+            status_stdout.is_empty(),
+            "expected clean working tree after checkout, got:\n{status_stdout}"
+        );
+
+        // Round-tripping back to feat and then main must also leave things clean.
+        store.checkout("feat").unwrap();
+        store.checkout("main").unwrap();
+        let status2 = std::process::Command::new("git")
+            .args(["status", "--porcelain"])
+            .current_dir(repo_root)
+            .output()
+            .expect("git status failed");
+        let status2_stdout = String::from_utf8_lossy(&status2.stdout);
+        assert!(
+            status2_stdout.is_empty(),
+            "expected clean working tree after checkout roundtrip, got:\n{status2_stdout}"
+        );
+    }
+
     // Regression for issue #162 specific to the Git backend's cross-branch merge:
     //
     // When a workflow writes on `feat`, switches back to `main`, and then runs

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -1600,4 +1600,534 @@ mod tests {
         assert_eq!(store.get(b"key1"), Some(b"main_value".to_vec())); // Keep main value
         assert_eq!(store.get(b"key2"), Some(b"feature_only".to_vec())); // Add from feature
     }
+
+    // Regression for issue #162: VersionedKvStore.merge on the File backend left the
+    // destination tree empty, and the merge commit's root hash pointed at nodes absent
+    // from .git/prolly/nodes/files/. Covers both the in-memory read after merge and the
+    // drop/reopen round-trip.
+    #[test]
+    fn test_file_versioned_kv_store_merge_persists_tree() {
+        use crate::diff::TakeSourceResolver;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("Failed to initialize git repository");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("Failed to configure git user name");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("Failed to configure git user email");
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = FileVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+
+        store.insert(b"A".to_vec(), b"1".to_vec()).unwrap();
+        store.insert(b"B".to_vec(), b"2".to_vec()).unwrap();
+        store.commit("seed").unwrap();
+
+        store.create_branch("feat").unwrap();
+        store.insert(b"C".to_vec(), b"3".to_vec()).unwrap();
+        store.commit("add C").unwrap();
+
+        store.checkout_generic("main").unwrap();
+        let resolver = TakeSourceResolver;
+        store.merge_generic("feat", &resolver).unwrap();
+
+        let mut keys = store.list_keys();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![b"A".to_vec(), b"B".to_vec(), b"C".to_vec()],
+            "list_keys after merge returned the wrong set"
+        );
+        assert_eq!(store.get(b"A"), Some(b"1".to_vec()));
+        assert_eq!(store.get(b"B"), Some(b"2".to_vec()));
+        assert_eq!(store.get(b"C"), Some(b"3".to_vec()));
+
+        drop(store);
+        let store2 = FileVersionedKvStore::<32>::open(&dataset_dir).unwrap();
+        let mut keys2 = store2.list_keys();
+        keys2.sort();
+        assert_eq!(
+            keys2,
+            vec![b"A".to_vec(), b"B".to_vec(), b"C".to_vec()],
+            "list_keys after drop/reopen returned wrong set — merge did not persist root+children"
+        );
+    }
+
+    // Regression for issue #162 (try_merge variant, matches the Python reproduction).
+    // Uses a larger dataset to force a multi-level tree, so the merge exercises both
+    // leaf-level inserts and internal-node rebalancing.
+    #[test]
+    fn test_file_versioned_kv_store_try_merge_persists_tree_multi_level() {
+        let temp_dir = TempDir::new().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("Failed to initialize git repository");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("Failed to configure git user name");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("Failed to configure git user email");
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = FileVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+
+        // Seed main with 50 keys — enough to force the tree past a single leaf.
+        for i in 0..50 {
+            let k = format!("main_key_{i:04}").into_bytes();
+            let v = format!("main_val_{i:04}").into_bytes();
+            store.insert(k, v).unwrap();
+        }
+        store.commit("seed main").unwrap();
+
+        // Fork feat branch and add another 50 disjoint keys.
+        store.create_branch("feat").unwrap();
+        for i in 0..50 {
+            let k = format!("feat_key_{i:04}").into_bytes();
+            let v = format!("feat_val_{i:04}").into_bytes();
+            store.insert(k, v).unwrap();
+        }
+        store.commit("add feat keys").unwrap();
+
+        // Back to main, try_merge feat.
+        store.checkout_generic("main").unwrap();
+        store.try_merge_generic("feat").unwrap();
+
+        // In-memory read must see all 100 keys.
+        let keys = store.list_keys();
+        assert_eq!(
+            keys.len(),
+            100,
+            "list_keys after merge expected 100, got {}",
+            keys.len()
+        );
+
+        // Every individual key must resolve via get().
+        for i in 0..50 {
+            let mk = format!("main_key_{i:04}").into_bytes();
+            let fk = format!("feat_key_{i:04}").into_bytes();
+            assert_eq!(
+                store.get(&mk),
+                Some(format!("main_val_{i:04}").into_bytes())
+            );
+            assert_eq!(
+                store.get(&fk),
+                Some(format!("feat_val_{i:04}").into_bytes())
+            );
+        }
+
+        // Drop + reopen must also see all 100 keys (this is the persistence round-trip
+        // that was broken in the issue: the merge commit's root hash pointed at nodes
+        // that weren't on disk).
+        drop(store);
+        let store2 = FileVersionedKvStore::<32>::open(&dataset_dir).unwrap();
+        let keys2 = store2.list_keys();
+        assert_eq!(
+            keys2.len(),
+            100,
+            "list_keys after drop/reopen expected 100, got {}",
+            keys2.len()
+        );
+
+        // Checkout elsewhere and back — this forces reload_tree_from_head_generic,
+        // which is the path that emits "Root node not found in storage" when the
+        // merge commit recorded a dangling root hash.
+        let mut store3 = FileVersionedKvStore::<32>::open(&dataset_dir).unwrap();
+        store3.checkout_generic("feat").unwrap();
+        store3.checkout_generic("main").unwrap();
+        let keys3 = store3.list_keys();
+        assert_eq!(
+            keys3.len(),
+            100,
+            "list_keys after checkout round-trip expected 100, got {}",
+            keys3.len()
+        );
+    }
+
+    // Regression for issue #162 — exercises the IgnoreAll resolver (Python's default),
+    // deletes that cross branches, and conflicts resolved by dropping source.
+    #[test]
+    fn test_file_versioned_kv_store_merge_with_deletes_and_conflicts() {
+        use crate::diff::IgnoreConflictsResolver;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git init failed");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git config name failed");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git config email failed");
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = FileVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+
+        // Seed with 60 keys across two shards (shard_a_*, shard_b_*).
+        for i in 0..30 {
+            store
+                .insert(
+                    format!("shard_a_{i:04}").into_bytes(),
+                    format!("base_a_{i:04}").into_bytes(),
+                )
+                .unwrap();
+            store
+                .insert(
+                    format!("shard_b_{i:04}").into_bytes(),
+                    format!("base_b_{i:04}").into_bytes(),
+                )
+                .unwrap();
+        }
+        store.commit("seed").unwrap();
+
+        // feat branch: delete 5 shard_a_* keys, modify 5 shard_b_* keys, add 10 new keys.
+        store.create_branch("feat").unwrap();
+        for i in 0..5 {
+            store
+                .delete(&format!("shard_a_{i:04}").into_bytes())
+                .unwrap();
+            store
+                .insert(
+                    format!("shard_b_{i:04}").into_bytes(),
+                    format!("feat_b_{i:04}").into_bytes(),
+                )
+                .unwrap();
+        }
+        for i in 0..10 {
+            store
+                .insert(
+                    format!("feat_new_{i:04}").into_bytes(),
+                    format!("feat_{i:04}").into_bytes(),
+                )
+                .unwrap();
+        }
+        store.commit("feat diverges").unwrap();
+
+        // main: modify some shard_a_* keys, add new keys.
+        store.checkout_generic("main").unwrap();
+        for i in 10..15 {
+            store
+                .insert(
+                    format!("shard_a_{i:04}").into_bytes(),
+                    format!("main_a_{i:04}").into_bytes(),
+                )
+                .unwrap();
+        }
+        for i in 0..8 {
+            store
+                .insert(
+                    format!("main_new_{i:04}").into_bytes(),
+                    format!("main_{i:04}").into_bytes(),
+                )
+                .unwrap();
+        }
+        store.commit("main diverges").unwrap();
+
+        // Merge feat into main with IgnoreConflictsResolver (keeps dest for conflicts).
+        let resolver = IgnoreConflictsResolver;
+        store.merge_generic("feat", &resolver).unwrap();
+
+        // Expected post-merge set:
+        //  shard_a_0000..0004 — deleted on feat, not modified on main → gone
+        //  shard_a_0005..0029 — 25 untouched
+        //  shard_b_0000..0004 — modified on feat only → feat_b_*
+        //  shard_b_0005..0029 — 25 untouched base_b_*
+        //  feat_new_0000..0009 — 10 added
+        //  main_new_0000..0007 — 8 added
+        // Total: 25 + 30 + 10 + 8 = 73
+        let keys = store.list_keys();
+        assert_eq!(
+            keys.len(),
+            73,
+            "in-memory list_keys after merge expected 73, got {}",
+            keys.len()
+        );
+
+        // Deleted keys must be gone.
+        for i in 0..5 {
+            assert_eq!(store.get(&format!("shard_a_{i:04}").into_bytes()), None);
+        }
+        // Feat values for shard_b_0..5 must win (feat modified, main didn't).
+        for i in 0..5 {
+            assert_eq!(
+                store.get(&format!("shard_b_{i:04}").into_bytes()),
+                Some(format!("feat_b_{i:04}").into_bytes())
+            );
+        }
+        // Main's new keys retained.
+        for i in 0..8 {
+            assert_eq!(
+                store.get(&format!("main_new_{i:04}").into_bytes()),
+                Some(format!("main_{i:04}").into_bytes())
+            );
+        }
+        // Feat's new keys merged in.
+        for i in 0..10 {
+            assert_eq!(
+                store.get(&format!("feat_new_{i:04}").into_bytes()),
+                Some(format!("feat_{i:04}").into_bytes())
+            );
+        }
+
+        // Drop + reopen + checkout round-trip must agree.
+        drop(store);
+        let mut store2 = FileVersionedKvStore::<32>::open(&dataset_dir).unwrap();
+        store2.checkout_generic("feat").unwrap();
+        store2.checkout_generic("main").unwrap();
+        let keys2 = store2.list_keys();
+        assert_eq!(
+            keys2.len(),
+            73,
+            "list_keys after drop/reopen/checkout-round-trip expected 73, got {}",
+            keys2.len()
+        );
+    }
+
+    // Regression for issue #162 on the Git backend. The Python binding defaults to
+    // Git backend (python.rs:617), so the issue's Python reproduction actually
+    // exercises this path. Test a drop+reopen and checkout round-trip after merge.
+    #[test]
+    fn test_git_versioned_kv_store_merge_persists_tree() {
+        let temp_dir = TempDir::new().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git init failed");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git config name failed");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git config email failed");
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+
+        store.insert(b"A".to_vec(), b"1".to_vec()).unwrap();
+        store.insert(b"B".to_vec(), b"2".to_vec()).unwrap();
+        store.commit("seed").unwrap();
+
+        store.create_branch("feat").unwrap();
+        store.insert(b"C".to_vec(), b"3".to_vec()).unwrap();
+        store.commit("add C").unwrap();
+
+        store.checkout("main").unwrap();
+        store.try_merge_generic("feat").unwrap();
+
+        // In-memory list_keys must see 3.
+        let mut keys = store.list_keys();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![b"A".to_vec(), b"B".to_vec(), b"C".to_vec()],
+            "Git backend: list_keys after merge wrong, got {:?}",
+            keys
+        );
+
+        // Drop + reopen + checkout round-trip.
+        drop(store);
+        let mut store2 = GitVersionedKvStore::<32>::open(&dataset_dir).unwrap();
+        let mut keys2 = store2.list_keys();
+        keys2.sort();
+        assert_eq!(
+            keys2,
+            vec![b"A".to_vec(), b"B".to_vec(), b"C".to_vec()],
+            "Git backend: list_keys after drop/reopen wrong"
+        );
+        store2.checkout("feat").unwrap();
+        store2.checkout("main").unwrap();
+        let mut keys3 = store2.list_keys();
+        keys3.sort();
+        assert_eq!(
+            keys3,
+            vec![b"A".to_vec(), b"B".to_vec(), b"C".to_vec()],
+            "Git backend: list_keys after checkout round-trip wrong"
+        );
+    }
+
+    // Regression for issue #162 specific to the Git backend's cross-branch merge:
+    //
+    // When a workflow writes on `feat`, switches back to `main`, and then runs
+    // `git reset --hard HEAD` (or any other operation that narrows the working-tree
+    // `prolly_hash_mappings` file back to a single branch's view), the in-memory
+    // mappings loaded by a subsequent open are a subset of what `feat` committed.
+    // `merge_generic` then looks up `feat`'s committed root hash in the current
+    // mappings, doesn't find it, and silently treats the source side of the merge
+    // as empty — dropping every key that lived in base.
+    //
+    // The fix routes merge's base/source reads through `HistoricalAccess::get_keys_at_ref`,
+    // whose Git-backend specialization reads the per-commit `prolly_hash_mappings`
+    // blob from the commit tree itself rather than the current working-tree state.
+    #[test]
+    fn test_git_merge_after_working_tree_narrowed_by_reset() {
+        let temp_dir = TempDir::new().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git init failed");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git config name failed");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git config email failed");
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+
+        // Seed main with enough keys to force a multi-level tree (some large values to
+        // push nodes past the single-leaf threshold, matching the reported reproduction).
+        for i in 0..6 {
+            let key = format!("seed_{i:04}").into_bytes();
+            let value = format!("v_{i:04}_").into_bytes().repeat(4000); // ~28KB each
+            store.insert(key, value).unwrap();
+        }
+        store.commit("seed").unwrap();
+        // Two more keys committed on main.
+        store.insert(b"main_a".to_vec(), b"va".to_vec()).unwrap();
+        store.commit("main a").unwrap();
+        store.insert(b"main_b".to_vec(), b"vb".to_vec()).unwrap();
+        store.commit("main b").unwrap();
+
+        // Branch feat, add C.
+        store.create_branch("feat").unwrap();
+        store.checkout("feat").unwrap();
+        store.insert(b"feat_c".to_vec(), b"vc".to_vec()).unwrap();
+        store.commit("feat c").unwrap();
+
+        // Back to main, then narrow the working-tree `prolly_hash_mappings` back to
+        // main's committed view via `git reset --hard HEAD`. This is what triggers the
+        // bug in the wild: any git operation (reset, checkout -f, clean) that rewrites
+        // the working tree wipes the cross-branch mappings from the on-disk file.
+        store.checkout("main").unwrap();
+        let reset = std::process::Command::new("git")
+            .args(["reset", "--hard", "HEAD"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git reset failed");
+        assert!(reset.status.success(), "git reset --hard failed");
+
+        // Reopen the store (mimics a fresh process).
+        drop(store);
+        let mut store = GitVersionedKvStore::<32>::open(&dataset_dir).unwrap();
+
+        // Merge feat into main. Before the fix this would log
+        // "Root node not found in storage for hash ...", treat source_kv as empty, and
+        // delete every key that lived in base.
+        store.try_merge_generic("feat").unwrap();
+
+        let keys = store.list_keys();
+        assert_eq!(
+            keys.len(),
+            9,
+            "expected 9 keys (6 seed + main_a + main_b + feat_c), got {}",
+            keys.len()
+        );
+        assert_eq!(store.get(b"main_a"), Some(b"va".to_vec()));
+        assert_eq!(store.get(b"main_b"), Some(b"vb".to_vec()));
+        assert_eq!(store.get(b"feat_c"), Some(b"vc".to_vec()));
+    }
+
+    // Mirrors the Python reproduction from issue #162 exactly: create_branch followed
+    // by explicit checkout (the Python flow does both), then try_merge on Git backend.
+    #[test]
+    fn test_git_merge_python_reproduction_exact() {
+        let temp_dir = TempDir::new().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git init failed");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git config name failed");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&temp_dir)
+            .output()
+            .expect("git config email failed");
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+
+        store.insert(b"A".to_vec(), b"1".to_vec()).unwrap();
+        store.insert(b"B".to_vec(), b"2".to_vec()).unwrap();
+        store.commit("seed").unwrap();
+
+        store.create_branch("feat").unwrap();
+        store.checkout("feat").unwrap(); // Python flow does this explicitly
+        store.insert(b"C".to_vec(), b"3".to_vec()).unwrap();
+        store.commit("add C").unwrap();
+
+        store.checkout("main").unwrap();
+        let (_commit_id, _) = (store.try_merge_generic("feat").unwrap(), ());
+
+        let mut keys = store.list_keys();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec![b"A".to_vec(), b"B".to_vec(), b"C".to_vec()],
+            "Git backend (Python-exact reproduction): list_keys after merge returned {:?}",
+            keys
+        );
+    }
 }

--- a/src/storage/git.rs
+++ b/src/storage/git.rs
@@ -199,24 +199,25 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
         hash: ValueDigest<N>,
         node: ProllyNode<N>,
     ) -> Result<(), StorageError> {
-        // Check if this node already exists in our mappings
-        let already_exists = self.hash_to_object_id.lock().contains_key(&hash);
-
         // Store in cache
         self.cache.lock().put(hash.clone(), Arc::new(node.clone()));
 
-        // Store as Git blob
+        // Store as Git blob (this is durable — the blob lives in the git object db)
         let blob_id = self
             .store_node_as_blob(&node)
             .map_err(|e| StorageError::Other(e.to_string()))?;
 
-        // Store the mapping between ProllyTree hash and Git object ID
+        // Record the mapping in memory. We used to also append it to
+        // `dataset_dir/prolly_hash_mappings` on every new insert, but doing so
+        // added each transient intermediate node (including ones produced by
+        // rebalances during `reload_tree_from_head`) to the working-tree file in
+        // unsorted append order. The result: `git status` spuriously reported
+        // the file as modified after any checkout, and cross-branch narrowing
+        // via `git reset` dropped mappings that merge later needed (GH-161, GH-162).
+        // The canonical on-disk snapshot is written atomically by
+        // `save_tree_config_to_git` at commit time, in sorted order, from the
+        // full in-memory map — so the per-insert write is redundant.
         self.hash_to_object_id.lock().insert(hash.clone(), blob_id);
-
-        // Only persist the mapping to filesystem if it's a new node
-        if !already_exists {
-            self.save_hash_mapping(&hash, &blob_id);
-        }
 
         Ok(())
     }
@@ -238,7 +239,19 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
         let mut configs = self.configs.lock();
         configs.insert(key.to_string(), config.to_vec());
 
-        // Also persist to filesystem for durability in the dataset directory
+        // The `tree_config` key is the canonical serialized TreeConfig used during
+        // merge/checkout/commit. Its on-disk form lives in
+        // `dataset_dir/prolly_config_tree_config` and is written by
+        // `save_tree_config_to_git` with `serde_json::to_string_pretty`. The compact
+        // `serde_json::to_vec` bytes handed in here are a byte-different
+        // serialization of the same logical config — writing them would leave the
+        // working tree file out of sync with what the last commit recorded and
+        // cause `git status` to spuriously report the file as modified (see GH-161).
+        // Skip the on-disk write for `tree_config` and keep only the in-memory copy.
+        if key == "tree_config" {
+            return;
+        }
+
         let config_path = self.dataset_dir.join(format!("prolly_config_{key}"));
         let _ = std::fs::write(config_path, config);
     }
@@ -262,27 +275,6 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
 }
 
 impl<const N: usize> GitNodeStorage<N> {
-    /// Save hash mapping to filesystem
-    fn save_hash_mapping(&self, hash: &ValueDigest<N>, object_id: &gix::ObjectId) {
-        let mapping_path = self.dataset_dir.join("prolly_hash_mappings");
-
-        // Read existing mappings
-        let mut mappings = if mapping_path.exists() {
-            std::fs::read_to_string(&mapping_path).unwrap_or_default()
-        } else {
-            String::new()
-        };
-
-        // Add new mapping - use simple format for now without hex dependency
-        let hash_bytes: Vec<String> = hash.0.iter().map(|b| format!("{b:02x}")).collect();
-        let hash_hex = hash_bytes.join("");
-        let object_hex = object_id.to_hex().to_string();
-        mappings.push_str(&format!("{hash_hex}:{object_hex}\n"));
-
-        // Write back
-        let _ = std::fs::write(mapping_path, mappings);
-    }
-
     /// Load hash mappings from filesystem
     fn load_hash_mappings(&self) {
         let mapping_path = self.dataset_dir.join("prolly_hash_mappings");


### PR DESCRIPTION
  GH-162 — merge corrupts destination branch ("Root node not found in storage")

  Cause: merge_generic and reload_tree_from_head_generic looked up commit root hashes in the current
  in-memory hash_to_object_id map. After operations that narrow the on-disk prolly_hash_mappings to one
  branch's view (e.g. git reset --hard), the other branch's root can't be resolved → source_kv silently
  empties → base keys get marked "deleted on source" → destination data lost.

  Fix (src/git/versioned_store/history.rs): route both methods through
  HistoricalAccess::get_keys_at_ref(commit_id.to_hex()). The Git backend's specialization reads the
  per-commit prolly_hash_mappings blob from the commit tree itself, so it works regardless of working-tree
   state.

  GH-161 — checkout leaves git status dirty

  Three compounding causes:

  1. No working-tree sync — checkout only rewrote .git/HEAD. Fix: new sync_working_tree_to_head() runs git
   checkout HEAD -- <dataset_dir> after updating HEAD, scoped so non-prolly files aren't touched.
  2. prolly_config_tree_config drift — save_tree_config_to_git wrote pretty JSON; persist_root →
  save_config overwrote it with compact JSON. Fix (src/storage/git.rs): GitNodeStorage::save_config skips
  the on-disk write for tree_config; commit-time pretty JSON is canonical.
  3. prolly_hash_mappings drift — per-insert unsorted appends + non-deterministic HashMap iteration at
  commit. Fix: removed the per-insert disk append (in-memory map + commit-time snapshot is sufficient) and
   sorted entries before writing in save_tree_config_to_git, making the file byte-deterministic.

  Tests added

  Seven regression tests in src/git/versioned_store/tests.rs, including the two targeted ones:
  test_git_checkout_leaves_working_tree_clean (GH-161) and
  test_git_merge_after_working_tree_narrowed_by_reset (GH-162). 118/118 lib tests pass; build/fmt/clippy
  clean.
