### PR TITLE
[GH-167] Fix the store write issues when not in a git reository

### DIFF
--- a/src/git/operations.rs
+++ b/src/git/operations.rs
@@ -337,18 +337,18 @@ impl<const N: usize> GitOperations<N> {
         &self,
         commit_id: &gix::ObjectId,
     ) -> Result<HashMap<Vec<u8>, Vec<u8>>, GitKvError> {
-        // Try to read prolly config and hash mappings directly from the commit
-        let current_dir = std::env::current_dir()
-            .map_err(|e| GitKvError::GitObjectError(format!("Failed to get current dir: {e}")))?;
-
-        // Get the dataset directory name relative to git root
-        let git_root =
-            self.store.git_repo().workdir().ok_or_else(|| {
-                GitKvError::GitObjectError("Not in a working directory".to_string())
+        // Resolve from the store's own dataset directory rather than process cwd
+        // (GH-167: historical reads must not depend on cwd when the store path is known).
+        let dataset_dir =
+            self.store.dataset_dir.as_ref().ok_or_else(|| {
+                GitKvError::GitObjectError("Dataset directory not set".to_string())
             })?;
 
-        let relative_path = current_dir.strip_prefix(git_root).map_err(|_| {
-            GitKvError::GitObjectError("Current directory not within git repository".to_string())
+        let git_root = GitVersionedKvStore::<N>::find_git_root(dataset_dir)
+            .ok_or_else(|| GitKvError::GitObjectError("Not in a git repository".to_string()))?;
+
+        let relative_path = dataset_dir.strip_prefix(&git_root).map_err(|_| {
+            GitKvError::GitObjectError("Dataset directory not within git repository".to_string())
         })?;
 
         let dataset_name = relative_path.to_string_lossy();

--- a/src/git/versioned_store/core.rs
+++ b/src/git/versioned_store/core.rs
@@ -24,7 +24,7 @@ where
     Self: TreeConfigSaver<N>,
 {
     /// Find the git repository root by walking up the directory tree
-    pub(super) fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<std::path::PathBuf> {
+    pub(crate) fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<std::path::PathBuf> {
         let mut current = start_path.as_ref().to_path_buf();
         loop {
             if current.join(".git").exists() {
@@ -398,16 +398,21 @@ where
 
     /// Get the dataset-specific staging file path
     fn get_staging_file_path(&self) -> Result<std::path::PathBuf, GitKvError> {
-        // Get the current directory relative to git root
-        let current_dir = std::env::current_dir().map_err(|e| {
-            GitKvError::GitObjectError(format!("Failed to get current directory: {e}"))
-        })?;
+        // Resolve from the store's own dataset directory rather than process cwd
+        // (GH-167: writes from a non-git cwd must not fail when the store path is known).
+        // Walking up from `dataset_dir` keeps `git_root` in the same form as
+        // `dataset_dir`, so the `strip_prefix` below stays consistent regardless of
+        // canonicalization differences.
+        let dataset_dir = self
+            .dataset_dir
+            .as_ref()
+            .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".to_string()))?;
 
-        let git_root = Self::find_git_root(&current_dir)
+        let git_root = Self::find_git_root(dataset_dir)
             .ok_or_else(|| GitKvError::GitObjectError("Not in a git repository".to_string()))?;
 
         // Create a dataset-specific identifier from the relative path
-        let relative_path = current_dir
+        let relative_path = dataset_dir
             .strip_prefix(&git_root)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to get relative path: {e}")))?;
 

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -2200,4 +2200,39 @@ mod tests {
             keys
         );
     }
+
+    /// Regression test for GH-167: write operations must succeed when the calling
+    /// process's cwd is outside any git working tree, as long as an explicit absolute
+    /// store path is supplied to `open()`. Before the fix, `get_staging_file_path()`
+    /// resolved the git root from `std::env::current_dir()`, so `insert`/`commit`
+    /// failed with "Not in a git repository" even though the store path was a valid
+    /// git repo.
+    #[test]
+    fn test_gh167_writes_succeed_when_cwd_is_outside_git_tree() {
+        // 1. Create a git repo with a dataset subdirectory and seed it. The init has
+        //    to run from inside the repo (CLI requirement), but the regression test
+        //    exercises the *open + write* path from a non-git cwd, which is the bug.
+        let repo = TempDir::new().unwrap();
+        gix::init(repo.path()).unwrap();
+        let dataset_dir = repo.path().join("dataset");
+        std::fs::create_dir_all(&dataset_dir).unwrap();
+        {
+            let _cwd = CwdGuard::set(&dataset_dir);
+            let _store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+        }
+
+        // 2. Switch to a cwd that is NOT inside any git tree.
+        let non_git_cwd = TempDir::new().unwrap();
+        let _cwd = CwdGuard::set(non_git_cwd.path());
+
+        // 3. Open the existing store via its absolute path and write to it. Before
+        //    the fix this failed at the first `insert` with "Not in a git repository".
+        let mut store = GitVersionedKvStore::<32>::open(&dataset_dir).unwrap();
+        store.insert(b"k".to_vec(), b"v".to_vec()).unwrap();
+        store.commit("gh167 write from non-git cwd").unwrap();
+
+        // 4. Re-open from the same non-git cwd and verify the write persisted.
+        let store2 = GitVersionedKvStore::<32>::open(&dataset_dir).unwrap();
+        assert_eq!(store2.get(b"k"), Some(b"v".to_vec()));
+    }
 }


### PR DESCRIPTION
Fixed GH-167. 

Root cause: get_staging_file_path() (called by every write) used std::env::current_dir() to find the git root, ignoring the store's own dataset_dir. Reads worked because the staging area is loaded into memory once at open() (which uses the explicit path), but writes called save_staging_area() on every op and tripped the cwd lookup. A second site in reconstruct_state_from_git_objects() had the same anti-pattern for historical reads.
