### PR TITLE
[GH-159] Add rocksdb as default python packaging in releases

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,11 +5,21 @@ on:
     types: [opened, ready_for_review, synchronize]
     paths:
       - 'python/**'
+      - 'src/python.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - '.github/workflows/python.yml'
   push:
     branches:
       - main
     paths:
       - 'python/**'
+      - 'src/python.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pyproject.toml'
+      - '.github/workflows/python.yml'
 
 jobs:
   build-wheels:
@@ -55,10 +65,38 @@ jobs:
         PYO3_CROSS_PYTHON_VERSION: "3.11"
       with:
         target: ${{ matrix.target }}
-        args: --release --out dist --features python --interpreter python3.11
+        args: --release --out dist --features python,git,sql,rocksdb_storage --interpreter python3.11
         sccache: 'true'
         manylinux: ${{ matrix.manylinux }}
         rust-toolchain: stable
+        before-script-linux: |
+          # librocksdb-sys needs clang/libclang for bindgen.
+          if command -v yum >/dev/null 2>&1; then
+            yum install -y clang
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update && apt-get install -y --no-install-recommends clang
+          fi
+
+    - name: Configure git identity for tests
+      if: runner.os == 'Linux'
+      run: |
+        git config --global user.name  "CI Test"
+        git config --global user.email "ci@example.com"
+
+    - name: Install wheel and pytest
+      if: runner.os == 'Linux'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        # Install the wheel built for this runner's platform.
+        WHEEL=$(ls dist/prollytree-*-cp38-abi3-manylinux*_${{ matrix.target }}.whl | head -1)
+        echo "Installing $WHEEL"
+        python -m pip install --force-reinstall "$WHEEL"
+
+    - name: Run Python tests
+      if: runner.os == 'Linux'
+      run: |
+        python -m pytest python/tests/ -v
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,10 +28,12 @@ jobs:
     strategy:
       matrix:
         include:
-          # Linux
+          # Linux. Pinned to manylinux_2_28 (AlmaLinux 8) because manylinux2014
+          # (CentOS 7) ships libclang 3.4 — too old for zstd-sys/bindgen, which
+          # needs clang_getTranslationUnitTargetInfo (libclang ≥ 6.0).
           - os: ubuntu-latest
             target: x86_64
-            manylinux: auto
+            manylinux: 2_28
 #          - os: ubuntu-latest
 #            target: aarch64
 #            manylinux: auto

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -93,10 +93,13 @@ jobs:
         echo "Installing $WHEEL"
         python -m pip install --force-reinstall "$WHEEL"
 
-    - name: Run Python tests
+    - name: Run Python tests (storage backends)
       if: runner.os == 'Linux'
+      # Scoped to the backend-coverage file; other test files have unrelated
+      # pre-existing setup issues (e.g. test_sql.py fixture doesn't git-init
+      # its tempdir). Broaden once those are fixed.
       run: |
-        python -m pytest python/tests/ -v
+        python -m pytest python/tests/test_versioned_kv.py -v
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,14 +112,15 @@ jobs:
     strategy:
       matrix:
         include:
-          # Linux x86_64
+          # Linux x86_64. Pinned to manylinux_2_28 (AlmaLinux 8) — manylinux2014
+          # (CentOS 7) ships libclang 3.4 which is too old for zstd-sys/bindgen.
           - os: ubuntu-latest
             target: x86_64
-            manylinux: auto
+            manylinux: 2_28
           # Linux aarch64
           - os: ubuntu-latest
             target: aarch64
-            manylinux: auto
+            manylinux: 2_28
           # Windows x86_64
           - os: windows-latest
             target: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,16 +143,25 @@ jobs:
         with:
           platforms: linux/arm64
 
+      - name: Install LLVM (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install -y llvm
+          echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" >> $env:GITHUB_ENV
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features python,git,sql -i python3.11
+          args: --release --out dist --features python,git,sql,rocksdb_storage -i python3.11
           manylinux: ${{ matrix.manylinux }}
           before-script-linux: |
-            # Install any system dependencies if needed
-            if [ "${{ matrix.target }}" = "aarch64" ]; then
-              echo "Setting up for ARM64 build"
+            # librocksdb-sys needs clang/libclang for bindgen and a C++ toolchain.
+            if command -v yum >/dev/null 2>&1; then
+              yum install -y clang
+            elif command -v apt-get >/dev/null 2>&1; then
+              apt-get update && apt-get install -y --no-install-recommends clang
             fi
 
       - name: Upload wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ Repository = "https://github.com/zhangfengcdt/prollytree.git"
 "Bug Tracker" = "https://github.com/zhangfengcdt/prollytree/issues"
 
 [tool.maturin]
-# Default features - can be overridden with --features flag
-features = ["python", "sql"]
+# Default features - can be overridden with --features flag.
+# rocksdb_storage is bundled so PyPI wheels (and sdist installs) ship with the
+# RocksDB backend enabled; users falling back to sdist need clang + a C++
+# toolchain installed for librocksdb-sys.
+features = ["python", "sql", "rocksdb_storage"]
 module-name = "prollytree"
 python-source = "python"

--- a/python/build_python.sh
+++ b/python/build_python.sh
@@ -74,7 +74,7 @@ for arg in "$@"; do
             shift
             ;;
         --all-features)
-            FEATURES="python sql"
+            FEATURES="python sql rocksdb_storage"
             shift
             ;;
     esac

--- a/python/build_python.sh
+++ b/python/build_python.sh
@@ -17,10 +17,13 @@
 # Usage:
 #   ./build_python.sh                    # Build with default Python bindings
 #   ./build_python.sh --with-sql         # Build with SQL support
-#   ./build_python.sh --all-features     # Build with all features (Python + SQL)
+#   ./build_python.sh --all-features     # Build with all features (Python + SQL + RocksDB)
 #   ./build_python.sh --features "python sql"  # Specify features explicitly
 #   ./build_python.sh --install          # Build and install the package
 #   ./build_python.sh --with-sql --install  # Build with SQL and install
+#
+# Note: --all-features compiles RocksDB from source via librocksdb-sys, which
+# requires clang/libclang and a C++ toolchain on the build host.
 
 set -e
 
@@ -33,8 +36,9 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     echo ""
     echo "Options:"
     echo "  --with-sql           Build with SQL support"
-    echo "  --all-features       Build with all features (Python + SQL)"
-    echo "  --features FEATURES  Specify features explicitly (e.g., 'python sql')"
+    echo "  --all-features       Build with all features (Python + SQL + RocksDB)"
+    echo "                       Requires clang/libclang + C++ toolchain for librocksdb-sys."
+    echo "  --features FEATURES  Specify features explicitly (e.g., 'python sql rocksdb_storage')"
     echo "  --install            Install the built package after building"
     echo "  --help, -h           Show this help message"
     echo ""
@@ -42,6 +46,7 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     echo "  ./build_python.sh                       # Basic Python bindings"
     echo "  ./build_python.sh --with-sql            # With SQL support"
     echo "  ./build_python.sh --with-sql --install  # Build and install with SQL"
+    echo "  ./build_python.sh --all-features        # With SQL + RocksDB (slower; needs clang)"
     exit 0
 fi
 

--- a/python/tests/test_versioned_kv.py
+++ b/python/tests/test_versioned_kv.py
@@ -193,6 +193,25 @@ def test_storage_backends():
             print(f"   Backend: {store_mem.storage_backend()}")
             print("   [OK] InMemory backend works")
 
+            # Test 4: RocksDB backend (skip if wheel built without rocksdb_storage)
+            print("\n[TEST] Test: RocksDB backend")
+            rocks_dir = os.path.join(tmpdir, "rocks_data")
+            os.makedirs(rocks_dir)
+            try:
+                store_rocks = VersionedKvStore(rocks_dir, StorageBackend.RocksDB)
+            except ValueError as exc:
+                if "rocksdb_storage" in str(exc):
+                    print("   [SKIP] wheel built without rocksdb_storage feature")
+                else:
+                    raise
+            else:
+                assert store_rocks.storage_backend() == StorageBackend.RocksDB
+                store_rocks.insert(b"key1", b"value1")
+                store_rocks.commit("RocksDB backend test")
+                assert store_rocks.get(b"key1") == b"value1"
+                print(f"   Backend: {store_rocks.storage_backend()}")
+                print("   [OK] RocksDB backend works")
+
             print("\n[OK] All storage backend tests completed successfully!")
         finally:
             os.chdir(original_dir)
@@ -347,7 +366,96 @@ def test_versioning_operations_on_file_backend():
             os.chdir(original_dir)
 
 
+def test_versioning_operations_on_rocksdb_backend():
+    """Test that versioning operations work on the RocksDB backend.
+
+    Mirrors test_versioning_operations_on_file_backend so the RocksDB
+    storage layer gets the same checkout / try_merge / diff / conflict-merge
+    coverage. Skipped when the wheel was built without `rocksdb_storage`.
+    """
+
+    original_dir = os.getcwd()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            print(f"\n[DIR] Testing versioning operations on RocksDB backend in: {tmpdir}")
+
+            subprocess.run(["git", "init"], cwd=tmpdir, check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmpdir, check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmpdir, check=True, capture_output=True)
+            os.chdir(tmpdir)
+
+            rocks_dir = os.path.join(tmpdir, "rocks_data")
+            os.makedirs(rocks_dir)
+            try:
+                store = VersionedKvStore(rocks_dir, StorageBackend.RocksDB)
+            except ValueError as exc:
+                if "rocksdb_storage" in str(exc):
+                    pytest.skip("wheel built without rocksdb_storage feature")
+                raise
+
+            store.insert(b"key1", b"value1")
+            store.commit("Initial commit on main")
+
+            # Create a feature branch and add a key
+            print("\n[TEST] Test: create_branch on RocksDB backend")
+            store.create_branch("feature")
+            print(f"   [OK] Created and switched to branch: {store.current_branch()}")
+            store.insert(b"feature_key", b"feature_value")
+            store.commit("Add feature key")
+
+            # Checkout back to main
+            print("\n[TEST] Test: checkout works on RocksDB backend")
+            store.checkout("main")
+            assert store.current_branch() == "main", "Should be on main branch"
+            assert store.get(b"feature_key") is None, "Feature key should not exist on main"
+            print(f"   [OK] Checkout to main succeeded, current branch: {store.current_branch()}")
+
+            # Add a non-conflicting change on main
+            store.insert(b"main_key", b"main_value")
+            store.commit("Add main key")
+
+            # try_merge should succeed without conflicts
+            print("\n[TEST] Test: try_merge works on RocksDB backend")
+            success, conflicts = store.try_merge("feature")
+            assert success, "Merge should succeed with no conflicts"
+            assert len(conflicts) == 0, "Should have no conflicts"
+            assert store.get(b"feature_key") == b"feature_value", "Feature key should exist after merge"
+            assert store.get(b"main_key") == b"main_value", "Main key should still exist"
+            print("   [OK] try_merge succeeded and merge result verified")
+
+            # diff between two commits
+            print("\n[TEST] Test: diff works on RocksDB backend")
+            history = store.log()
+            if len(history) >= 2:
+                diffs = store.diff(history[1]["id"], history[0]["id"])
+                print(f"   [OK] diff returned {len(diffs)} differences")
+            else:
+                print("   [SKIP] Not enough commits to test diff")
+
+            # Conflict resolution via TakeDestination
+            print("\n[TEST] Test: merge with conflict resolution on RocksDB backend")
+            store.create_branch("conflict-branch")
+            store.update(b"key1", b"conflict_value")
+            store.commit("Change key1 on conflict-branch")
+
+            store.checkout("main")
+            store.update(b"key1", b"main_updated_value")
+            store.commit("Change key1 on main")
+
+            from prollytree import ConflictResolution
+            merge_commit = store.merge("conflict-branch", ConflictResolution.TakeDestination)
+            assert store.get(b"key1") == b"main_updated_value", "Should keep main's value"
+            print(f"   [OK] Merge with conflict resolution succeeded, commit: {merge_commit[:8]}")
+
+            print("\n[OK] All versioning operations on RocksDB backend completed successfully!")
+        finally:
+            os.chdir(original_dir)
+
+
 if __name__ == "__main__":
     test_versioned_kv_store()
     test_storage_backends()
+    test_rocksdb_storage_backend()
     test_versioning_operations_on_file_backend()
+    test_versioning_operations_on_rocksdb_backend()

--- a/python/tests/test_versioned_kv.py
+++ b/python/tests/test_versioned_kv.py
@@ -20,6 +20,23 @@ import subprocess
 import pytest
 from prollytree import VersionedKvStore, StorageBackend
 
+
+# By default the RocksDB tests must FAIL when the wheel under test was not built
+# with `rocksdb_storage` — that is the packaging regression this test exists to
+# catch (CI/PyPI wheels are expected to ship the feature). For local builds that
+# intentionally omit RocksDB (e.g. `--with-sql` without the rocksdb toolchain),
+# set PROLLYTREE_TEST_SKIP_MISSING_BACKENDS=1 to opt into skip-instead-of-fail.
+_ROCKSDB_MISSING_MARKER = "rocksdb_storage"
+
+
+def _handle_missing_rocksdb(exc):
+    """Re-raise unless the local opt-in env var is set, in which case skip."""
+    if _ROCKSDB_MISSING_MARKER not in str(exc):
+        raise exc
+    if os.environ.get("PROLLYTREE_TEST_SKIP_MISSING_BACKENDS"):
+        pytest.skip("wheel built without rocksdb_storage feature (opt-in skip)")
+    raise exc
+
 def test_versioned_kv_store():
     """Test the versioned key-value store functionality."""
 
@@ -193,18 +210,26 @@ def test_storage_backends():
             print(f"   Backend: {store_mem.storage_backend()}")
             print("   [OK] InMemory backend works")
 
-            # Test 4: RocksDB backend (skip if wheel built without rocksdb_storage)
+            # Test 4: RocksDB backend.
+            # Defaults to failing if the wheel was built without rocksdb_storage
+            # (catches packaging regressions). With PROLLYTREE_TEST_SKIP_MISSING_BACKENDS=1
+            # we print-skip and continue so the prior Git/File/InMemory passes
+            # remain visible (using pytest.skip here would mark the whole test
+            # skipped and hide them).
             print("\n[TEST] Test: RocksDB backend")
             rocks_dir = os.path.join(tmpdir, "rocks_data")
             os.makedirs(rocks_dir)
+            store_rocks = None
             try:
                 store_rocks = VersionedKvStore(rocks_dir, StorageBackend.RocksDB)
             except ValueError as exc:
-                if "rocksdb_storage" in str(exc):
-                    print("   [SKIP] wheel built without rocksdb_storage feature")
+                if _ROCKSDB_MISSING_MARKER in str(exc) and os.environ.get(
+                    "PROLLYTREE_TEST_SKIP_MISSING_BACKENDS"
+                ):
+                    print("   [SKIP] wheel built without rocksdb_storage feature (opt-in)")
                 else:
                     raise
-            else:
+            if store_rocks is not None:
                 assert store_rocks.storage_backend() == StorageBackend.RocksDB
                 store_rocks.insert(b"key1", b"value1")
                 store_rocks.commit("RocksDB backend test")
@@ -220,8 +245,10 @@ def test_storage_backends():
 def test_rocksdb_storage_backend():
     """End-to-end smoke test for the RocksDB storage backend.
 
-    Skipped when the wheel under test was not built with the `rocksdb_storage`
-    feature — the Rust binding raises ValueError with that exact message string.
+    Fails by default if the wheel under test was not built with the
+    `rocksdb_storage` feature — that is the packaging regression this test
+    exists to catch. Set PROLLYTREE_TEST_SKIP_MISSING_BACKENDS=1 to opt into
+    a skip on local builds that intentionally omit RocksDB.
     """
 
     original_dir = os.getcwd()
@@ -241,9 +268,7 @@ def test_rocksdb_storage_backend():
             try:
                 store = VersionedKvStore(rocks_dir, StorageBackend.RocksDB)
             except ValueError as exc:
-                if "rocksdb_storage" in str(exc):
-                    pytest.skip("wheel built without rocksdb_storage feature")
-                raise
+                _handle_missing_rocksdb(exc)
 
             assert store.storage_backend() == StorageBackend.RocksDB
 
@@ -371,7 +396,9 @@ def test_versioning_operations_on_rocksdb_backend():
 
     Mirrors test_versioning_operations_on_file_backend so the RocksDB
     storage layer gets the same checkout / try_merge / diff / conflict-merge
-    coverage. Skipped when the wheel was built without `rocksdb_storage`.
+    coverage. Fails by default if the wheel was built without
+    `rocksdb_storage`; set PROLLYTREE_TEST_SKIP_MISSING_BACKENDS=1 to opt
+    into a skip on local builds.
     """
 
     original_dir = os.getcwd()
@@ -390,9 +417,7 @@ def test_versioning_operations_on_rocksdb_backend():
             try:
                 store = VersionedKvStore(rocks_dir, StorageBackend.RocksDB)
             except ValueError as exc:
-                if "rocksdb_storage" in str(exc):
-                    pytest.skip("wheel built without rocksdb_storage feature")
-                raise
+                _handle_missing_rocksdb(exc)
 
             store.insert(b"key1", b"value1")
             store.commit("Initial commit on main")

--- a/python/tests/test_versioned_kv.py
+++ b/python/tests/test_versioned_kv.py
@@ -17,6 +17,7 @@
 import tempfile
 import os
 import subprocess
+import pytest
 from prollytree import VersionedKvStore, StorageBackend
 
 def test_versioned_kv_store():
@@ -193,6 +194,63 @@ def test_storage_backends():
             print("   [OK] InMemory backend works")
 
             print("\n[OK] All storage backend tests completed successfully!")
+        finally:
+            os.chdir(original_dir)
+
+
+def test_rocksdb_storage_backend():
+    """End-to-end smoke test for the RocksDB storage backend.
+
+    Skipped when the wheel under test was not built with the `rocksdb_storage`
+    feature — the Rust binding raises ValueError with that exact message string.
+    """
+
+    original_dir = os.getcwd()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            print(f"\n[DIR] Testing RocksDB backend in: {tmpdir}")
+
+            subprocess.run(["git", "init"], cwd=tmpdir, check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmpdir, check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmpdir, check=True, capture_output=True)
+
+            rocks_dir = os.path.join(tmpdir, "rocks_data")
+            os.makedirs(rocks_dir)
+            os.chdir(rocks_dir)
+
+            try:
+                store = VersionedKvStore(rocks_dir, StorageBackend.RocksDB)
+            except ValueError as exc:
+                if "rocksdb_storage" in str(exc):
+                    pytest.skip("wheel built without rocksdb_storage feature")
+                raise
+
+            assert store.storage_backend() == StorageBackend.RocksDB
+
+            # Round-trip: insert, commit, read back
+            store.insert(b"alpha", b"1")
+            store.insert(b"beta", b"2")
+            commit_id = store.commit("RocksDB initial")
+            assert store.get(b"alpha") == b"1"
+            assert store.get(b"beta") == b"2"
+            assert commit_id  # non-empty commit hash
+
+            # Update + delete should also persist
+            store.insert(b"alpha", b"1-updated")
+            store.delete(b"beta")
+            store.commit("RocksDB update")
+            assert store.get(b"alpha") == b"1-updated"
+            assert store.get(b"beta") is None
+
+            # Reopen the on-disk store and confirm the data survives the drop
+            del store
+            reopened = VersionedKvStore.open(rocks_dir, StorageBackend.RocksDB)
+            assert reopened.storage_backend() == StorageBackend.RocksDB
+            assert reopened.get(b"alpha") == b"1-updated"
+            assert reopened.get(b"beta") is None
+
+            print("   [OK] RocksDB backend round-trip + reopen passed")
         finally:
             os.chdir(original_dir)
 


### PR DESCRIPTION
## Summary
  - Bundle the `rocksdb_storage` feature into PyPI wheels and the sdist so `StorageBackend.RocksDB` works on `pip install prollytree` without a source rebuild
  - Add end-to-end Python tests for the RocksDB backend (round-trip, reopen, full versioning ops) and wire them into CI alongside Git/File/InMemory coverage
  - Provision the right C++/libclang toolchain on every build target so `librocksdb-sys` + `zstd-sys` bindgen passes succeed

## Motivation
The Rust crate has exposed `rocksdb_storage` as an optional feature for a while, and `src/python.rs` already wires the RocksDB backend behind it. But `release.yml` built wheels with only `--features python,git,sql`, so every PyPI wheel through v0.3.3 raised `"RocksDB storage backend requires 'rocksdb_storage' feature to be enabled"` at runtime — despite `python/README.md` and the `.pyi` stubs documenting RocksDB as a supported backend. No Python-level test ever exercised the RocksDB code path either, so we'd be shipping it untested.
