### PR TITLE
Fix the conflict config files shared by VersionedKvStore and NamespacedKvStore

### DIFF
--- a/src/git/versioned_store/backends.rs
+++ b/src/git/versioned_store/backends.rs
@@ -46,22 +46,13 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         self.metadata.repo()
     }
 
-    /// Save both tree config and hash mappings to git for GitNodeStorage
+    /// Write the tree config + hash mappings to the dataset directory so
+    /// they get picked up by the next git commit.
     fn save_tree_config_to_git(&self) -> Result<(), GitKvError> {
-        // For GitNodeStorage, we need to ensure the config and hash mappings are
-        // available in the dataset directory so they can be committed to git
-
-        // Get the current tree configuration
         let config = self.tree.config.clone();
-
-        // Serialize the configuration to JSON
         let config_json = serde_json::to_string_pretty(&config)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to serialize config: {e}")))?;
 
-        // Write config to the dataset directory under ``self.config_filename``
-        // (default: ``prolly_config_tree_config``; ``NamespacedKvStore`` sets
-        // its inner to ``prolly_config_namespaced_root`` so the two layouts
-        // can share a dataset_dir without clobbering each other's root hash).
         let config_path = self.tree.storage.dataset_dir().join(&self.config_filename);
         std::fs::write(&config_path, config_json)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to write config file: {e}")))?;
@@ -540,18 +531,17 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         Self::init_with_config_filename(path, DEFAULT_TREE_CONFIG_FILENAME)
     }
 
-    /// Like :py:meth:`init`, but persists the serialized tree config to
-    /// ``config_filename`` (under the dataset directory) instead of the
-    /// default. Used by :class:`NamespacedKvStore` so its inner store
-    /// doesn't clobber a sibling ``VersionedKvStore``'s root-hash file
-    /// when both share a dataset directory.
+    /// Like [`init`], but persists the serialized tree config to
+    /// `config_filename` instead of the default. Used by
+    /// `NamespacedKvStore` so its inner store doesn't share a root-hash
+    /// file with a sibling `VersionedKvStore` in the same dataset_dir.
     pub fn init_with_config_filename<P: AsRef<Path>>(
         path: P,
         config_filename: &str,
     ) -> Result<Self, GitKvError> {
         let path = path.as_ref();
 
-        // Safety check: prevent initializing at git root to avoid `git add -A .` staging all files
+        // Refuse to init at git root — `git add -A .` would stage everything.
         if Self::is_in_git_root(path)? {
             return Err(GitKvError::GitObjectError(
                 "Cannot initialize git-prolly in git root directory. \
@@ -561,40 +551,29 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
             ));
         }
 
-        // Find the git repository
         let git_root = Self::find_git_root(path).ok_or_else(|| {
             GitKvError::GitObjectError(
                 "Not inside a git repository. Please run from within a git repository.".to_string(),
             )
         })?;
 
-        // For GitVersionedKvStore, use the user-provided path as the dataset directory
-        // This allows config files to be versioned in git commits
         let dataset_dir = path.to_path_buf();
         std::fs::create_dir_all(&dataset_dir).map_err(|e| {
             GitKvError::GitObjectError(format!("Failed to create dataset directory: {e}"))
         })?;
 
-        // Check if the store is already initialized by looking for config files.
-        // Detect both the caller's requested filename AND the default — a
-        // namespaced reopen of a default-init store should still route to
-        // ``open`` rather than spuriously re-initializing.
+        // Idempotent init: also check the default filename so reopening an
+        // old default-layout store as namespaced doesn't double-initialize.
         let config_path = dataset_dir.join(config_filename);
         let default_config_path = dataset_dir.join(DEFAULT_TREE_CONFIG_FILENAME);
         let mappings_path = dataset_dir.join("prolly_hash_mappings");
 
         if config_path.exists() || default_config_path.exists() || mappings_path.exists() {
-            // Store already exists, use open instead to load existing configuration.
             return Self::open_with_config_filename(path, config_filename);
         }
 
-        // Open the existing git repository
         let git_repo = gix::open(&git_root).map_err(|e| GitKvError::GitOpenError(Box::new(e)))?;
-
-        // Create GitNodeStorage with user-provided path for versioned files
         let storage = GitNodeStorage::new(git_repo.clone(), dataset_dir.clone())?;
-
-        // Create ProllyTree with default config
         let config: TreeConfig<N> = TreeConfig::default();
         let tree = ProllyTree::new(storage, config);
 
@@ -608,10 +587,7 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
             config_filename: config_filename.to_string(),
         };
 
-        // Save initial configuration
         let _ = store.tree.save_config();
-
-        // Create initial commit (which will include prolly metadata files)
         store.commit("Initial commit")?;
 
         Ok(store)
@@ -622,18 +598,15 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         Self::open_with_config_filename(path, DEFAULT_TREE_CONFIG_FILENAME)
     }
 
-    /// Like :py:meth:`open`, but reads the serialized tree config from
-    /// ``config_filename`` (under the dataset directory) instead of the
-    /// default. Used by :class:`NamespacedKvStore` to open its inner
-    /// store without picking up a sibling ``VersionedKvStore``'s root
-    /// hash from the default file.
+    /// Like [`open`], but reads the serialized tree config from
+    /// `config_filename` instead of the default.
     pub fn open_with_config_filename<P: AsRef<Path>>(
         path: P,
         config_filename: &str,
     ) -> Result<Self, GitKvError> {
         let path = path.as_ref();
 
-        // Safety check: prevent opening at git root to avoid `git add -A .` staging all files
+        // Refuse to open at git root — `git add -A .` would stage everything.
         if Self::is_in_git_root(path)? {
             return Err(GitKvError::GitObjectError(
                 "Cannot open git-prolly in git root directory. \
@@ -643,36 +616,25 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
             ));
         }
 
-        // Find the git repository
         let git_root = Self::find_git_root(path).ok_or_else(|| {
             GitKvError::GitObjectError(
                 "Not inside a git repository. Please run from within a git repository.".to_string(),
             )
         })?;
 
-        // For GitVersionedKvStore, use the user-provided path as the dataset directory
-        // This allows config files to be versioned in git commits
         let dataset_dir = path.to_path_buf();
-
-        // Open existing Git repository
         let git_repo = gix::open(&git_root).map_err(|e| GitKvError::GitOpenError(Box::new(e)))?;
-
-        // Create GitNodeStorage with user-provided path for versioned files
         let storage = GitNodeStorage::new(git_repo.clone(), dataset_dir.clone())?;
 
-        // Load tree configuration from dataset directory under the
-        // requested filename, with a backward-compatibility fallback to
-        // the default filename. This lets an existing store created
-        // before the namespaced-config split (where everything was
-        // under ``prolly_config_tree_config``) be re-opened as a
-        // ``NamespacedKvStore`` without manual migration.
+        // Resolve which config file to load: prefer the requested filename,
+        // fall back to the default for pre-split stores. The next commit
+        // through this handle will write the requested filename, completing
+        // the migration silently.
         let config_path = dataset_dir.join(config_filename);
         let fallback_path = dataset_dir.join(DEFAULT_TREE_CONFIG_FILENAME);
         let resolved_path = if config_path.exists() {
             config_path
         } else if fallback_path.exists() && config_filename != DEFAULT_TREE_CONFIG_FILENAME {
-            // Pre-split layout — read the legacy filename. The next commit
-            // will write the requested filename, completing the migration.
             fallback_path
         } else {
             return Err(GitKvError::GitObjectError(format!(
@@ -687,25 +649,21 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         let config: TreeConfig<N> = serde_json::from_str(&config_data)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to parse config file: {e}")))?;
 
-        // Try to load existing tree from storage
         let tree = if let Some(existing_tree) =
             ProllyTree::load_from_storage(storage.clone(), config.clone())
         {
             existing_tree
         } else if config.root_hash.is_some() {
-            // We have a saved root hash but failed to load the tree
-            // This could be due to missing hash mappings or git objects
-            // For read-only operations, we should try to work with what we have
-            // rather than creating a new empty tree that would overwrite the config
+            // Saved hash but can't load — likely missing git objects or hash
+            // mappings. Keep the config rather than overwriting with empty so
+            // read-side callers can still try to work with what's there.
             eprintln!("Warning: Failed to load tree from saved root hash. This may indicate missing git objects or corrupted hash mappings.");
             eprintln!("Attempting to create tree with saved config to avoid data loss...");
             ProllyTree::new(storage, config)
         } else {
-            // No saved root hash - this is a genuinely new/empty tree
             ProllyTree::new(storage, config)
         };
 
-        // Get current branch
         let current_branch = git_repo
             .head_ref()
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to get head ref: {e}")))?
@@ -722,14 +680,11 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
             config_filename: config_filename.to_string(),
         };
 
-        // Load staging area from file if it exists
         store.load_staging_area()?;
 
-        // Note: We intentionally do NOT call reload_tree_from_head() here
-        // because git-prolly commands should read from the current directory's
-        // tree-config and mapping files, not from git HEAD.
-        // The tree was already loaded from local storage by load_from_storage() above.
-
+        // Don't reload_tree_from_head — git-prolly reads from the dataset
+        // directory's config/mapping files, not git HEAD. The tree was
+        // already loaded from local storage above.
         Ok(store)
     }
 

--- a/src/git/versioned_store/backends.rs
+++ b/src/git/versioned_store/backends.rs
@@ -12,7 +12,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use super::{HistoricalAccess, HistoricalCommitAccess, TreeConfigSaver, VersionedKvStore};
+use super::{
+    HistoricalAccess, HistoricalCommitAccess, TreeConfigSaver, VersionedKvStore,
+    DEFAULT_TREE_CONFIG_FILENAME,
+};
 use crate::config::TreeConfig;
 use crate::diff::{ConflictResolver, IgnoreConflictsResolver};
 use crate::digest::ValueDigest;
@@ -55,12 +58,11 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         let config_json = serde_json::to_string_pretty(&config)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to serialize config: {e}")))?;
 
-        // Write config to the dataset directory
-        let config_path = self
-            .tree
-            .storage
-            .dataset_dir()
-            .join("prolly_config_tree_config");
+        // Write config to the dataset directory under ``self.config_filename``
+        // (default: ``prolly_config_tree_config``; ``NamespacedKvStore`` sets
+        // its inner to ``prolly_config_namespaced_root`` so the two layouts
+        // can share a dataset_dir without clobbering each other's root hash).
+        let config_path = self.tree.storage.dataset_dir().join(&self.config_filename);
         std::fs::write(&config_path, config_json)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to write config file: {e}")))?;
 
@@ -533,8 +535,20 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         Ok(())
     }
 
-    /// Initialize a new versioned KV store with Git storage (default)
+    /// Initialize a new versioned KV store with Git storage (default).
     pub fn init<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        Self::init_with_config_filename(path, DEFAULT_TREE_CONFIG_FILENAME)
+    }
+
+    /// Like :py:meth:`init`, but persists the serialized tree config to
+    /// ``config_filename`` (under the dataset directory) instead of the
+    /// default. Used by :class:`NamespacedKvStore` so its inner store
+    /// doesn't clobber a sibling ``VersionedKvStore``'s root-hash file
+    /// when both share a dataset directory.
+    pub fn init_with_config_filename<P: AsRef<Path>>(
+        path: P,
+        config_filename: &str,
+    ) -> Result<Self, GitKvError> {
         let path = path.as_ref();
 
         // Safety check: prevent initializing at git root to avoid `git add -A .` staging all files
@@ -561,13 +575,17 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
             GitKvError::GitObjectError(format!("Failed to create dataset directory: {e}"))
         })?;
 
-        // Check if the store is already initialized by looking for config files
-        let config_path = dataset_dir.join("prolly_config_tree_config");
+        // Check if the store is already initialized by looking for config files.
+        // Detect both the caller's requested filename AND the default — a
+        // namespaced reopen of a default-init store should still route to
+        // ``open`` rather than spuriously re-initializing.
+        let config_path = dataset_dir.join(config_filename);
+        let default_config_path = dataset_dir.join(DEFAULT_TREE_CONFIG_FILENAME);
         let mappings_path = dataset_dir.join("prolly_hash_mappings");
 
-        if config_path.exists() || mappings_path.exists() {
-            // Store already exists, use open instead to load existing configuration
-            return Self::open(path);
+        if config_path.exists() || default_config_path.exists() || mappings_path.exists() {
+            // Store already exists, use open instead to load existing configuration.
+            return Self::open_with_config_filename(path, config_filename);
         }
 
         // Open the existing git repository
@@ -587,6 +605,7 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
             current_branch: "main".to_string(),
             storage_backend: StorageBackend::Git,
             dataset_dir: Some(dataset_dir),
+            config_filename: config_filename.to_string(),
         };
 
         // Save initial configuration
@@ -598,8 +617,20 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         Ok(store)
     }
 
-    /// Open an existing versioned KV store with Git storage (default)
+    /// Open an existing versioned KV store with Git storage (default).
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
+        Self::open_with_config_filename(path, DEFAULT_TREE_CONFIG_FILENAME)
+    }
+
+    /// Like :py:meth:`open`, but reads the serialized tree config from
+    /// ``config_filename`` (under the dataset directory) instead of the
+    /// default. Used by :class:`NamespacedKvStore` to open its inner
+    /// store without picking up a sibling ``VersionedKvStore``'s root
+    /// hash from the default file.
+    pub fn open_with_config_filename<P: AsRef<Path>>(
+        path: P,
+        config_filename: &str,
+    ) -> Result<Self, GitKvError> {
         let path = path.as_ref();
 
         // Safety check: prevent opening at git root to avoid `git add -A .` staging all files
@@ -629,16 +660,29 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         // Create GitNodeStorage with user-provided path for versioned files
         let storage = GitNodeStorage::new(git_repo.clone(), dataset_dir.clone())?;
 
-        // Load tree configuration from dataset directory
-        let config_path = dataset_dir.join("prolly_config_tree_config");
-        if !config_path.exists() {
-            return Err(GitKvError::GitObjectError(
-                "Config file not found. The store may not be initialized. \
-                Call init() to create a new store."
-                    .to_string(),
-            ));
-        }
-        let config_data = std::fs::read_to_string(&config_path)
+        // Load tree configuration from dataset directory under the
+        // requested filename, with a backward-compatibility fallback to
+        // the default filename. This lets an existing store created
+        // before the namespaced-config split (where everything was
+        // under ``prolly_config_tree_config``) be re-opened as a
+        // ``NamespacedKvStore`` without manual migration.
+        let config_path = dataset_dir.join(config_filename);
+        let fallback_path = dataset_dir.join(DEFAULT_TREE_CONFIG_FILENAME);
+        let resolved_path = if config_path.exists() {
+            config_path
+        } else if fallback_path.exists() && config_filename != DEFAULT_TREE_CONFIG_FILENAME {
+            // Pre-split layout — read the legacy filename. The next commit
+            // will write the requested filename, completing the migration.
+            fallback_path
+        } else {
+            return Err(GitKvError::GitObjectError(format!(
+                "Config file not found ({} or {}). The store may not be \
+                initialized. Call init() to create a new store.",
+                config_filename, DEFAULT_TREE_CONFIG_FILENAME,
+            )));
+        };
+
+        let config_data = std::fs::read_to_string(&resolved_path)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to read config file: {e}")))?;
         let config: TreeConfig<N> = serde_json::from_str(&config_data)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to parse config file: {e}")))?;
@@ -675,6 +719,7 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
             current_branch,
             storage_backend: StorageBackend::Git,
             dataset_dir: Some(dataset_dir),
+            config_filename: config_filename.to_string(),
         };
 
         // Load staging area from file if it exists
@@ -682,7 +727,7 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
 
         // Note: We intentionally do NOT call reload_tree_from_head() here
         // because git-prolly commands should read from the current directory's
-        // prolly_config_tree_config and mapping files, not from git HEAD.
+        // tree-config and mapping files, not from git HEAD.
         // The tree was already loaded from local storage by load_from_storage() above.
 
         Ok(store)
@@ -721,7 +766,7 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
             .collect::<Vec<_>>()
             .join("/");
 
-        let config_path = format!("{}/prolly_config_tree_config", relative_path_str);
+        let config_path = format!("{}/{}", relative_path_str, self.config_filename);
         let mapping_path = format!("{}/prolly_hash_mappings", relative_path_str);
 
         let config_result = self.metadata.read_file_at_commit(commit_id, &config_path);
@@ -916,6 +961,7 @@ impl<const N: usize> VersionedKvStore<N, InMemoryNodeStorage<N>, GitMetadataBack
             current_branch: "main".to_string(),
             storage_backend: StorageBackend::InMemory,
             dataset_dir: Some(dataset_dir),
+            config_filename: DEFAULT_TREE_CONFIG_FILENAME.to_string(),
         };
 
         // Create initial commit
@@ -1019,6 +1065,7 @@ impl<const N: usize> VersionedKvStore<N, FileNodeStorage<N>, GitMetadataBackend>
             current_branch: "main".to_string(),
             storage_backend: StorageBackend::File,
             dataset_dir: Some(dataset_dir),
+            config_filename: DEFAULT_TREE_CONFIG_FILENAME.to_string(),
         };
 
         // Create initial commit (which will save config to dataset_dir)
@@ -1120,6 +1167,7 @@ impl<const N: usize> VersionedKvStore<N, FileNodeStorage<N>, GitMetadataBackend>
             current_branch,
             storage_backend: StorageBackend::File,
             dataset_dir: Some(dataset_dir),
+            config_filename: DEFAULT_TREE_CONFIG_FILENAME.to_string(),
         };
 
         // Load staging area from file if it exists
@@ -1215,6 +1263,7 @@ impl<const N: usize> VersionedKvStore<N, RocksDBNodeStorage<N>, GitMetadataBacke
             current_branch: "main".to_string(),
             storage_backend: StorageBackend::RocksDB,
             dataset_dir: Some(dataset_dir),
+            config_filename: DEFAULT_TREE_CONFIG_FILENAME.to_string(),
         };
 
         // Create initial commit (which will save config to dataset_dir)
@@ -1306,6 +1355,7 @@ impl<const N: usize> VersionedKvStore<N, RocksDBNodeStorage<N>, GitMetadataBacke
             current_branch,
             storage_backend: StorageBackend::RocksDB,
             dataset_dir: Some(dataset_dir),
+            config_filename: DEFAULT_TREE_CONFIG_FILENAME.to_string(),
         };
 
         // Load staging area from file if it exists

--- a/src/git/versioned_store/history.rs
+++ b/src/git/versioned_store/history.rs
@@ -59,8 +59,10 @@ where
         })?;
 
         // Construct the file path and use '/' separators for git tree paths
-        // (git uses forward slashes regardless of platform)
-        let config_path = relative_path.join("prolly_config_tree_config");
+        // (git uses forward slashes regardless of platform). Uses
+        // ``self.config_filename`` so namespaced stores read their own
+        // config file rather than the default-filename sibling.
+        let config_path = relative_path.join(&self.config_filename);
         let path_str = config_path
             .components()
             .map(|c| c.as_os_str().to_string_lossy())
@@ -69,8 +71,9 @@ where
         Ok(path_str)
     }
 
-    /// Read the tree config from a specific commit
-    /// This gets the prolly_config_tree_config file from the commit to extract root hash
+    /// Read the tree config from a specific commit. Uses
+    /// ``self.config_filename`` so namespaced stores read their own
+    /// serialized ``TreeConfig`` rather than the default sibling.
     pub(super) fn read_tree_config_from_commit(
         &self,
         commit_id: &gix::ObjectId,
@@ -86,7 +89,10 @@ where
                 Ok(tree_config)
             }
             Err(_) => {
-                eprintln!("Warning: prolly_config_tree_config not found in commit {commit_id}, using default config");
+                eprintln!(
+                    "Warning: {} not found in commit {commit_id}, using default config",
+                    self.config_filename
+                );
                 Ok(TreeConfig::default())
             }
         }

--- a/src/git/versioned_store/history.rs
+++ b/src/git/versioned_store/history.rs
@@ -58,10 +58,7 @@ where
             GitKvError::GitObjectError("Dataset directory is not inside git repository".to_string())
         })?;
 
-        // Construct the file path and use '/' separators for git tree paths
-        // (git uses forward slashes regardless of platform). Uses
-        // ``self.config_filename`` so namespaced stores read their own
-        // config file rather than the default-filename sibling.
+        // git tree paths always use forward slashes.
         let config_path = relative_path.join(&self.config_filename);
         let path_str = config_path
             .components()
@@ -71,9 +68,7 @@ where
         Ok(path_str)
     }
 
-    /// Read the tree config from a specific commit. Uses
-    /// ``self.config_filename`` so namespaced stores read their own
-    /// serialized ``TreeConfig`` rather than the default sibling.
+    /// Read the tree config from a specific commit.
     pub(super) fn read_tree_config_from_commit(
         &self,
         commit_id: &gix::ObjectId,

--- a/src/git/versioned_store/mod.rs
+++ b/src/git/versioned_store/mod.rs
@@ -136,27 +136,21 @@ pub struct VersionedKvStore<
     pub(crate) staging_area: HashMap<Vec<u8>, Option<Vec<u8>>>, // None = deleted
     pub(crate) current_branch: String,
     pub(crate) storage_backend: StorageBackend,
-    /// Dataset directory for storing config and other metadata for all backends
-    /// (File/RocksDB/InMemory/Git). Git init/open paths set this from
-    /// `storage.dataset_dir()`, and commit()/merge rely on this field being `Some`.
+    /// Dataset directory for config and other metadata. Set from
+    /// `storage.dataset_dir()` at init/open; commit/merge require `Some`.
     pub(crate) dataset_dir: Option<std::path::PathBuf>,
-    /// Filename (relative to ``dataset_dir``) for the serialized
-    /// ``TreeConfig`` root hash. Defaults to
-    /// :const:`DEFAULT_TREE_CONFIG_FILENAME`. ``NamespacedKvStore``
-    /// overrides this to :const:`NAMESPACED_TREE_CONFIG_FILENAME` on
-    /// the inner store so the two store types stop fighting over a
-    /// single shared file in the same dataset directory.
+    /// Filename under `dataset_dir` for the serialized `TreeConfig`. Lets
+    /// `NamespacedKvStore` route its inner store to a distinct file so the
+    /// two store types can share a dataset directory.
     pub(crate) config_filename: String,
 }
 
-/// Default filename for ``VersionedKvStore``'s ``TreeConfig`` serialization.
+/// Default `TreeConfig` filename written by `VersionedKvStore`.
 pub const DEFAULT_TREE_CONFIG_FILENAME: &str = "prolly_config_tree_config";
 
-/// Filename used when a ``VersionedKvStore`` is embedded as the inner
-/// store of a ``NamespacedKvStore``. Distinct from
-/// :const:`DEFAULT_TREE_CONFIG_FILENAME` so both store types can
-/// coexist on the same dataset directory without overwriting each
-/// other's root-hash pointer.
+/// `TreeConfig` filename used when a `VersionedKvStore` is the inner
+/// store of a `NamespacedKvStore`. Kept separate from
+/// `DEFAULT_TREE_CONFIG_FILENAME` so both layouts can share a directory.
 pub const NAMESPACED_TREE_CONFIG_FILENAME: &str = "prolly_config_namespaced_root";
 
 /// Type alias for backward compatibility (Git storage)

--- a/src/git/versioned_store/mod.rs
+++ b/src/git/versioned_store/mod.rs
@@ -140,7 +140,24 @@ pub struct VersionedKvStore<
     /// (File/RocksDB/InMemory/Git). Git init/open paths set this from
     /// `storage.dataset_dir()`, and commit()/merge rely on this field being `Some`.
     pub(crate) dataset_dir: Option<std::path::PathBuf>,
+    /// Filename (relative to ``dataset_dir``) for the serialized
+    /// ``TreeConfig`` root hash. Defaults to
+    /// :const:`DEFAULT_TREE_CONFIG_FILENAME`. ``NamespacedKvStore``
+    /// overrides this to :const:`NAMESPACED_TREE_CONFIG_FILENAME` on
+    /// the inner store so the two store types stop fighting over a
+    /// single shared file in the same dataset directory.
+    pub(crate) config_filename: String,
 }
+
+/// Default filename for ``VersionedKvStore``'s ``TreeConfig`` serialization.
+pub const DEFAULT_TREE_CONFIG_FILENAME: &str = "prolly_config_tree_config";
+
+/// Filename used when a ``VersionedKvStore`` is embedded as the inner
+/// store of a ``NamespacedKvStore``. Distinct from
+/// :const:`DEFAULT_TREE_CONFIG_FILENAME` so both store types can
+/// coexist on the same dataset directory without overwriting each
+/// other's root-hash pointer.
+pub const NAMESPACED_TREE_CONFIG_FILENAME: &str = "prolly_config_namespaced_root";
 
 /// Type alias for backward compatibility (Git storage)
 pub type GitVersionedKvStore<const N: usize> = VersionedKvStore<N, GitNodeStorage<N>>;

--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -1000,28 +1000,19 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
 
     /// Initialize a new namespaced store with Git storage.
     ///
-    /// Idempotent: if the dataset directory already contains a
-    /// namespaced config file (``prolly_config_namespaced_root``) or
-    /// a namespace registry, dispatches to :py:meth:`open` instead of
-    /// re-initializing. This prevents the historical bug where every
-    /// caller of ``NamespacedKvStore::init`` added an
-    /// ``"Initial namespaced store"`` commit to git history, even on
-    /// already-initialized stores.
+    /// Idempotent: dispatches to [`open`] if the dataset already has a
+    /// namespaced layout, so callers don't accumulate "Initial namespaced
+    /// store" commits on re-init. Detection only looks at namespace-specific
+    /// markers — a sibling `VersionedKvStore` in the same dataset_dir does
+    /// not count as "already initialized" for the namespaced store.
     pub fn init<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
         let path_ref = path.as_ref();
-        // Fast existence check — only the namespace-specific markers,
-        // since a sibling ``VersionedKvStore`` may legitimately own the
-        // default-filename config in the same dataset_dir.
         if path_ref.join(NAMESPACED_TREE_CONFIG_FILENAME).exists()
             || path_ref.join("prolly_namespace_registry").exists()
         {
             return Self::open(path);
         }
 
-        // Inner store writes its ``TreeConfig`` to
-        // ``prolly_config_namespaced_root`` instead of the default file
-        // so a sibling ``VersionedKvStore`` on the same dataset_dir
-        // doesn't have its root hash clobbered (and vice versa).
         let inner = VersionedKvStore::<N, GitNodeStorage<N>>::init_with_config_filename(
             &path,
             NAMESPACED_TREE_CONFIG_FILENAME,
@@ -1050,25 +1041,21 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
             externalize_threshold: None,
         };
 
-        // Create the default namespace with an empty tree
         let default_tree = ProllyTree::new(store.inner.tree.storage.clone(), TreeConfig::default());
         store
             .namespaces
             .insert(DEFAULT_NAMESPACE.to_string(), default_tree);
 
-        // Commit initial state (writes V2 marker + registry)
+        // Writes the V2 marker + registry.
         store.commit("Initial namespaced store")?;
 
         Ok(store)
     }
 
-    /// Open an existing store. Automatically detects V1/V2 format.
+    /// Open an existing store. Auto-detects V1/V2 format and silently
+    /// migrates pre-split (default-filename) stores via the open-side
+    /// fallback in `VersionedKvStore::open_with_config_filename`.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
-        // Open the inner store from the namespaced config filename. The
-        // ``VersionedKvStore::open_with_config_filename`` impl falls
-        // back to the default filename when the namespaced one is
-        // absent, so a pre-existing default-layout store is still
-        // openable as namespaced (one-time migration on next commit).
         let inner = VersionedKvStore::<N, GitNodeStorage<N>>::open_with_config_filename(
             &path,
             NAMESPACED_TREE_CONFIG_FILENAME,

--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -33,7 +33,7 @@ limitations under the License.
 //! All namespace trees share the same [`NodeStorage`] backend (content-addressed,
 //! so there is no collision risk).
 
-use super::{TreeConfigSaver, VersionedKvStore};
+use super::{TreeConfigSaver, VersionedKvStore, NAMESPACED_TREE_CONFIG_FILENAME};
 use crate::config::TreeConfig;
 use crate::diff::{ConflictResolver, IgnoreConflictsResolver, MergeConflict};
 use crate::digest::ValueDigest;
@@ -999,9 +999,33 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
     }
 
     /// Initialize a new namespaced store with Git storage.
+    ///
+    /// Idempotent: if the dataset directory already contains a
+    /// namespaced config file (``prolly_config_namespaced_root``) or
+    /// a namespace registry, dispatches to :py:meth:`open` instead of
+    /// re-initializing. This prevents the historical bug where every
+    /// caller of ``NamespacedKvStore::init`` added an
+    /// ``"Initial namespaced store"`` commit to git history, even on
+    /// already-initialized stores.
     pub fn init<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
-        // Delegate to VersionedKvStore for git setup
-        let inner = VersionedKvStore::<N, GitNodeStorage<N>>::init(&path)?;
+        let path_ref = path.as_ref();
+        // Fast existence check — only the namespace-specific markers,
+        // since a sibling ``VersionedKvStore`` may legitimately own the
+        // default-filename config in the same dataset_dir.
+        if path_ref.join(NAMESPACED_TREE_CONFIG_FILENAME).exists()
+            || path_ref.join("prolly_namespace_registry").exists()
+        {
+            return Self::open(path);
+        }
+
+        // Inner store writes its ``TreeConfig`` to
+        // ``prolly_config_namespaced_root`` instead of the default file
+        // so a sibling ``VersionedKvStore`` on the same dataset_dir
+        // doesn't have its root hash clobbered (and vice versa).
+        let inner = VersionedKvStore::<N, GitNodeStorage<N>>::init_with_config_filename(
+            &path,
+            NAMESPACED_TREE_CONFIG_FILENAME,
+        )?;
 
         let mut store = NamespacedKvStore {
             inner,
@@ -1040,7 +1064,15 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
 
     /// Open an existing store. Automatically detects V1/V2 format.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitKvError> {
-        let inner = VersionedKvStore::<N, GitNodeStorage<N>>::open(&path)?;
+        // Open the inner store from the namespaced config filename. The
+        // ``VersionedKvStore::open_with_config_filename`` impl falls
+        // back to the default filename when the namespaced one is
+        // absent, so a pre-existing default-layout store is still
+        // openable as namespaced (one-time migration on next commit).
+        let inner = VersionedKvStore::<N, GitNodeStorage<N>>::open_with_config_filename(
+            &path,
+            NAMESPACED_TREE_CONFIG_FILENAME,
+        )?;
 
         let dataset_dir = inner
             .dataset_dir


### PR DESCRIPTION
Summary

Two prollytree store types — VersionedKvStore and NamespacedKvStore — currently share a single on-disk config file (prolly_config_tree_config) when both are opened against the same dataset directory. Each store writes its own root hash to that file on commit; the last writer wins. A process opening the other store afterwards reads a root hash that points at a tree it can't reconstruct, silently falls back to an empty tree, and every subsequent read returns None.

This PR splits the config file by owner: NamespacedKvStore writes its inner store's TreeConfig to prolly_config_namespaced_root; VersionedKvStore keeps prolly_config_tree_config unchanged. Also fixes NamespacedKvStore::init to be idempotent — it currently appends an "Initial namespaced store" commit to history on every call, even for already-initialized stores.

