### PR TITLE
Bump deps: pyo3 0.22→0.28, bincode 1→2, lru, uuid, assert_cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,11 +445,22 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -2724,6 +2735,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,15 +2977,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -3285,11 +3298,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3371,15 +3384,6 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -3901,37 +3905,32 @@ checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3939,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3951,9 +3950,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4710,9 +4709,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -5131,16 +5130,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ureq"
@@ -5183,9 +5182,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5209,6 +5208,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ sha2 = "0.10"
 tracing = { version = "0.1.37", optional = true }
 rand = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
-bincode = "1.3.3"
+bincode = { version = "2.0", features = ["serde"] }
 thiserror = "2.0"
 parking_lot = "0.12"
 twox-hash = "2.0"
@@ -32,15 +32,15 @@ schemars = "0.8"
 parquet = { version = "58.1.0", features = ["arrow"] }
 gix = { version = "0.81", features = ["blocking-network-client"], optional = true }
 clap = { version = "4.6", features = ["derive"], optional = true }
-lru = { version = "0.16", optional = true }
+lru = { version = "0.18", optional = true }
 hex = { version = "0.4", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
 gluesql-core = { version = "0.19", optional = true }
 async-trait = { version = "0.1", optional = true }
-uuid = { version = "1.0", features = ["v4"], optional = true }
+uuid = { version = "1.23", features = ["v4"], optional = true }
 futures = { version = "0.3", optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync"], optional = true }
-pyo3 = { version = "0.22", features = ["extension-module", "abi3-py38"], optional = true }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py38"], optional = true }
 rocksdb = { version = "0.22", optional = true }
 candle-core = { version = "0.10", optional = true }
 candle-nn = { version = "0.10", optional = true }
@@ -50,7 +50,7 @@ ureq = { version = "2.10", optional = true, default-features = false, features =
 dirs = { version = "5.0", optional = true }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd = "2.2"
 bytes = "1.10.1"
 criterion = "0.5"
 predicates = "3.0"

--- a/src/git/operations.rs
+++ b/src/git/operations.rs
@@ -600,9 +600,10 @@ impl<const N: usize> GitOperations<N> {
             .ok_or_else(|| GitKvError::GitObjectError("Root object is not a blob".to_string()))?;
 
         // Deserialize the prolly node
-        let root_node: ProllyNode<N> = bincode::deserialize(blob_ref.data).map_err(|e| {
-            GitKvError::GitObjectError(format!("Failed to deserialize root node: {e}"))
-        })?;
+        let root_node: ProllyNode<N> =
+            crate::serde_bincode::deserialize(blob_ref.data).map_err(|e| {
+                GitKvError::GitObjectError(format!("Failed to deserialize root node: {e}"))
+            })?;
 
         // Traverse the tree and collect all key-value pairs
         let mut result = HashMap::new();
@@ -652,7 +653,7 @@ impl<const N: usize> GitOperations<N> {
                         })?;
 
                     let child_node: ProllyNode<N> =
-                        bincode::deserialize(blob_ref.data).map_err(|e| {
+                        crate::serde_bincode::deserialize(blob_ref.data).map_err(|e| {
                             GitKvError::GitObjectError(format!(
                                 "Failed to deserialize child node: {e}"
                             ))

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -26,8 +26,11 @@ pub enum GitKvError {
     #[error("Git object error: {0}")]
     GitObjectError(String),
 
-    #[error("Serialization error: {0}")]
-    SerializationError(#[from] bincode::Error),
+    #[error("Serialization encode error: {0}")]
+    SerializationEncodeError(#[from] bincode::error::EncodeError),
+
+    #[error("Serialization decode error: {0}")]
+    SerializationDecodeError(#[from] bincode::error::DecodeError),
 
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),

--- a/src/git/versioned_store/core.rs
+++ b/src/git/versioned_store/core.rs
@@ -370,8 +370,8 @@ where
         let staging_file = self.get_staging_file_path()?;
 
         // Serialize the staging area
-        let serialized =
-            bincode::serialize(&self.staging_area).map_err(GitKvError::SerializationError)?;
+        let serialized = crate::serde_bincode::serialize(&self.staging_area)
+            .map_err(GitKvError::SerializationEncodeError)?;
 
         std::fs::write(staging_file, serialized).map_err(|e| {
             GitKvError::GitObjectError(format!("Failed to write staging area: {e}"))
@@ -389,8 +389,8 @@ where
                 GitKvError::GitObjectError(format!("Failed to read staging area: {e}"))
             })?;
 
-            self.staging_area =
-                bincode::deserialize(&data).map_err(GitKvError::SerializationError)?;
+            self.staging_area = crate::serde_bincode::deserialize(&data)
+                .map_err(GitKvError::SerializationDecodeError)?;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub mod proximity;
 pub mod python;
 #[cfg(feature = "rocksdb_storage")]
 pub mod rocksdb;
+pub(crate) mod serde_bincode;
 #[cfg(feature = "sql")]
 pub mod sql;
 pub mod storage;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1711,8 +1711,8 @@ mod tests {
         let mut node = ProllyNode::<32>::default();
         node.split = true;
         node.merged = true;
-        let bytes = bincode::serialize(&node).unwrap();
-        let de: ProllyNode<32> = bincode::deserialize(&bytes).unwrap();
+        let bytes = crate::serde_bincode::serialize(&node).unwrap();
+        let de: ProllyNode<32> = crate::serde_bincode::deserialize(&bytes).unwrap();
         assert!(
             !de.split && !de.merged,
             "Split/merged flags should not be serialized"

--- a/src/proximity/index.rs
+++ b/src/proximity/index.rs
@@ -162,7 +162,7 @@ pub struct PersistedProximityState<const N: usize> {
 pub fn deserialize_persisted_state<const N: usize>(
     bytes: &[u8],
 ) -> Result<PersistedProximityState<N>, ProximityError> {
-    let state: SavedProximityState<N> = bincode::deserialize(bytes)
+    let state: SavedProximityState<N> = crate::serde_bincode::deserialize(bytes)
         .map_err(|e| ProximityError::InvalidSavedState(e.to_string()))?;
     Ok(PersistedProximityState {
         config: state.config,
@@ -322,8 +322,8 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
             entries: self.entries.clone(),
             root: self.root.clone(),
         };
-        let bytes =
-            bincode::serialize(&state).map_err(|e| ProximityError::Serialize(e.to_string()))?;
+        let bytes = crate::serde_bincode::serialize(&state)
+            .map_err(|e| ProximityError::Serialize(e.to_string()))?;
         self.storage.save_config(&Self::state_key(name), &bytes);
         self.storage.sync()?;
         Ok(self.root.clone())
@@ -335,7 +335,7 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
         let bytes = storage
             .get_config(&Self::state_key(name))
             .ok_or_else(|| ProximityError::NotFound(name.to_string()))?;
-        let state: SavedProximityState<N> = bincode::deserialize(&bytes)
+        let state: SavedProximityState<N> = crate::serde_bincode::deserialize(&bytes)
             .map_err(|e| ProximityError::InvalidSavedState(e.to_string()))?;
         Ok(Self {
             entries: state.entries,

--- a/src/proximity/node.rs
+++ b/src/proximity/node.rs
@@ -91,7 +91,7 @@ impl<const N: usize> ProximityNode<N> {
     /// Content hash over the canonical bincode encoding of the node. The
     /// digest is what `NodeStorage` will index this node under in later PRs.
     pub fn get_hash(&self) -> ValueDigest<N> {
-        let bytes = bincode::serialize(self).expect("ProximityNode bincode serialize");
+        let bytes = crate::serde_bincode::serialize(self).expect("ProximityNode bincode serialize");
         ValueDigest::new(&bytes)
     }
 }
@@ -146,8 +146,8 @@ mod tests {
             2,
             1,
         );
-        let bytes = bincode::serialize(&original).unwrap();
-        let restored: ProximityNode<32> = bincode::deserialize(&bytes).unwrap();
+        let bytes = crate::serde_bincode::serialize(&original).unwrap();
+        let restored: ProximityNode<32> = crate::serde_bincode::deserialize(&bytes).unwrap();
         assert_eq!(original.level, restored.level);
         assert_eq!(original.ids, restored.ids);
         assert_eq!(original.vectors, restored.vectors);

--- a/src/proximity/storage.rs
+++ b/src/proximity/storage.rs
@@ -35,7 +35,8 @@ const PROX_SENTINEL: &[u8] = b"\x01prox";
 pub(crate) fn wrap_proximity_node<const N: usize>(
     node: &ProximityNode<N>,
 ) -> Result<ProllyNode<N>, ProximityError> {
-    let payload = bincode::serialize(node).map_err(|e| ProximityError::Serialize(e.to_string()))?;
+    let payload = crate::serde_bincode::serialize(node)
+        .map_err(|e| ProximityError::Serialize(e.to_string()))?;
     // Start from `Default` to inherit the chunking-config defaults (base,
     // modulus, pattern), then overwrite the fields we care about. Both
     // chunk-size bounds at usize::MAX make the rolling-hash chunker treat the
@@ -63,7 +64,7 @@ pub(crate) fn unwrap_proximity_node<const N: usize>(
             "wrapper is not a proximity node".into(),
         ));
     }
-    bincode::deserialize::<ProximityNode<N>>(&wrapper.values[0])
+    crate::serde_bincode::deserialize::<ProximityNode<N>>(&wrapper.values[0])
         .map_err(|e| ProximityError::Corrupted(format!("bincode: {e}")))
 }
 

--- a/src/proximity/text_index.rs
+++ b/src/proximity/text_index.rs
@@ -262,7 +262,7 @@ where
     S: NodeStorage<N>,
 {
     if let Some(bytes) = storage.get_config(state_key) {
-        let state: SavedTextIndexState = bincode::deserialize(&bytes)
+        let state: SavedTextIndexState = crate::serde_bincode::deserialize(&bytes)
             .map_err(|e| TextIndexError::InvalidSavedState(e.to_string()))?;
         if state.embedder_id != embedder.id() || state.embedder_version != embedder.version() {
             return Err(TextIndexError::EmbedderMismatch {
@@ -288,8 +288,8 @@ where
             level_bits,
             max_bucket_size,
         };
-        let bytes =
-            bincode::serialize(&state).map_err(|e| TextIndexError::Serialize(e.to_string()))?;
+        let bytes = crate::serde_bincode::serialize(&state)
+            .map_err(|e| TextIndexError::Serialize(e.to_string()))?;
         storage.save_config(state_key, &bytes);
         Ok(())
     }
@@ -401,8 +401,8 @@ impl<const N: usize, E: Embedder, S: NodeStorage<N>> TextIndex<N, E, S> {
             level_bits: cfg.level_bits,
             max_bucket_size: cfg.max_bucket_size,
         };
-        let bytes =
-            bincode::serialize(&state).map_err(|e| TextIndexError::Serialize(e.to_string()))?;
+        let bytes = crate::serde_bincode::serialize(&state)
+            .map_err(|e| TextIndexError::Serialize(e.to_string()))?;
         self.inner
             .storage()
             .save_config(&text_state_key(name), &bytes);

--- a/src/python.rs
+++ b/src/python.rs
@@ -21,6 +21,7 @@ use parking_lot::Mutex;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyBytesMethods, PyDict, PyList};
+use pyo3::IntoPyObjectExt;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -169,7 +170,7 @@ impl PyProllyTree {
         let key_vec = key.as_bytes().to_vec();
         let value_vec = value.as_bytes().to_vec();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.insert(key_vec, value_vec);
@@ -182,7 +183,7 @@ impl PyProllyTree {
         let keys: Vec<Vec<u8>> = items.iter().map(|(k, _)| k.clone()).collect();
         let values: Vec<Vec<u8>> = items.iter().map(|(_, v)| v.clone()).collect();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.insert_batch(&keys, &values);
@@ -194,7 +195,7 @@ impl PyProllyTree {
     fn find(&self, py: Python, key: &Bound<'_, PyBytes>) -> PyResult<Option<Py<PyBytes>>> {
         let key_vec = key.as_bytes().to_vec();
 
-        let result = py.allow_threads(|| {
+        let result = py.detach(|| {
             let tree_wrapper = self.tree.lock();
             with_tree!(tree_wrapper, tree, { tree.find(&key_vec) })
         });
@@ -204,7 +205,7 @@ impl PyProllyTree {
                 // Find the key in the node and return the corresponding value
                 if let Some(key_index) = node.keys.iter().position(|k| k == &key_vec) {
                     if key_index < node.values.len() {
-                        Ok(Some(PyBytes::new_bound(py, &node.values[key_index]).into()))
+                        Ok(Some(PyBytes::new(py, &node.values[key_index]).into()))
                     } else {
                         Ok(None)
                     }
@@ -225,7 +226,7 @@ impl PyProllyTree {
         let key_vec = key.as_bytes().to_vec();
         let value_vec = value.as_bytes().to_vec();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.update(key_vec, value_vec);
@@ -237,7 +238,7 @@ impl PyProllyTree {
     fn delete(&mut self, py: Python, key: &Bound<'_, PyBytes>) -> PyResult<()> {
         let key_vec = key.as_bytes().to_vec();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.delete(&key_vec);
@@ -249,7 +250,7 @@ impl PyProllyTree {
     fn delete_batch(&mut self, py: Python, keys: Vec<Vec<u8>>) -> PyResult<()> {
         let key_vecs: Vec<Vec<u8>> = keys;
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let mut tree_wrapper = self.tree.lock();
             with_tree_mut!(tree_wrapper, tree, {
                 tree.delete_batch(&key_vecs);
@@ -272,8 +273,8 @@ impl PyProllyTree {
         let tree_wrapper = self.tree.lock();
         let hash_opt = with_tree!(tree_wrapper, tree, tree.get_root_hash());
         match hash_opt {
-            Some(hash) => Ok(PyBytes::new_bound(py, hash.as_ref()).into()),
-            None => Ok(PyBytes::new_bound(py, &[0u8; 32]).into()),
+            Some(hash) => Ok(PyBytes::new(py, hash.as_ref()).into()),
+            None => Ok(PyBytes::new(py, &[0u8; 32]).into()),
         }
     }
 
@@ -295,15 +296,15 @@ impl PyProllyTree {
     fn generate_proof(&self, py: Python, key: &Bound<'_, PyBytes>) -> PyResult<Py<PyBytes>> {
         let key_vec = key.as_bytes().to_vec();
 
-        let proof_bytes = py.allow_threads(|| {
+        let proof_bytes = py.detach(|| {
             let tree_wrapper = self.tree.lock();
             let proof = with_tree!(tree_wrapper, tree, tree.generate_proof(&key_vec));
 
-            bincode::serialize(&proof)
+            crate::serde_bincode::serialize(&proof)
                 .map_err(|e| PyValueError::new_err(format!("Proof serialization failed: {}", e)))
         })?;
 
-        Ok(PyBytes::new_bound(py, &proof_bytes).into())
+        Ok(PyBytes::new(py, &proof_bytes).into())
     }
 
     #[pyo3(signature = (proof_bytes, key, expected_value=None))]
@@ -318,8 +319,8 @@ impl PyProllyTree {
         let proof_vec = proof_bytes.as_bytes().to_vec();
         let value_option = expected_value.map(|v| v.as_bytes().to_vec());
 
-        py.allow_threads(|| {
-            let proof: Proof<32> = bincode::deserialize(&proof_vec).map_err(|e| {
+        py.detach(|| {
+            let proof: Proof<32> = crate::serde_bincode::deserialize(&proof_vec).map_err(|e| {
                 PyValueError::new_err(format!("Proof deserialization failed: {}", e))
             })?;
 
@@ -336,10 +337,10 @@ impl PyProllyTree {
         // Implement a key-value level diff by comparing actual data
         // This approach works regardless of tree structure differences
 
-        let dict = PyDict::new_bound(py);
-        let added = PyDict::new_bound(py);
-        let removed = PyDict::new_bound(py);
-        let modified = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
+        let added = PyDict::new(py);
+        let removed = PyDict::new(py);
+        let modified = PyDict::new(py);
 
         // We'll need to collect all keys from both trees and compare values
         // For simplicity, we'll implement this by getting all key-value pairs
@@ -365,7 +366,7 @@ impl PyProllyTree {
     }
 
     fn save_config(&self, py: Python) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let tree_wrapper = self.tree.lock();
             with_tree!(tree_wrapper, tree, {
                 let _ = tree.save_config();
@@ -375,7 +376,7 @@ impl PyProllyTree {
     }
 }
 
-#[pyclass(name = "StorageBackend", eq, eq_int)]
+#[pyclass(name = "StorageBackend", eq, eq_int, from_py_object)]
 #[derive(Clone, PartialEq)]
 enum PyStorageBackend {
     InMemory,
@@ -448,7 +449,7 @@ macro_rules! with_versioned_store_mut {
 }
 
 /// Python wrapper for MergeConflict
-#[pyclass(name = "MergeConflict")]
+#[pyclass(name = "MergeConflict", from_py_object)]
 #[derive(Clone)]
 struct PyMergeConflict {
     key: Vec<u8>,
@@ -461,15 +462,12 @@ struct PyMergeConflict {
 impl PyMergeConflict {
     #[getter]
     fn key(&self, py: Python) -> PyResult<Py<PyBytes>> {
-        Ok(PyBytes::new_bound(py, &self.key).into())
+        Ok(PyBytes::new(py, &self.key).into())
     }
 
     #[getter]
     fn base_value(&self, py: Python) -> PyResult<Option<Py<PyBytes>>> {
-        Ok(self
-            .base_value
-            .as_ref()
-            .map(|v| PyBytes::new_bound(py, v).into()))
+        Ok(self.base_value.as_ref().map(|v| PyBytes::new(py, v).into()))
     }
 
     #[getter]
@@ -477,7 +475,7 @@ impl PyMergeConflict {
         Ok(self
             .source_value
             .as_ref()
-            .map(|v| PyBytes::new_bound(py, v).into()))
+            .map(|v| PyBytes::new(py, v).into()))
     }
 
     #[getter]
@@ -485,7 +483,7 @@ impl PyMergeConflict {
         Ok(self
             .destination_value
             .as_ref()
-            .map(|v| PyBytes::new_bound(py, v).into()))
+            .map(|v| PyBytes::new(py, v).into()))
     }
 
     fn __repr__(&self) -> String {
@@ -506,7 +504,7 @@ impl PyMergeConflict {
 }
 
 /// Python enum for conflict resolution strategies
-#[pyclass(name = "ConflictResolution", eq, eq_int)]
+#[pyclass(name = "ConflictResolution", eq, eq_int, from_py_object)]
 #[derive(Clone, PartialEq)]
 enum PyConflictResolution {
     IgnoreAll,
@@ -515,7 +513,7 @@ enum PyConflictResolution {
 }
 
 /// Python wrapper for DiffOperation
-#[pyclass(name = "DiffOperation")]
+#[pyclass(name = "DiffOperation", from_py_object)]
 #[derive(Clone)]
 struct PyDiffOperation {
     operation_type: String,
@@ -533,26 +531,17 @@ impl PyDiffOperation {
 
     #[getter]
     fn value(&self, py: Python) -> PyResult<Option<Py<PyBytes>>> {
-        Ok(self
-            .value
-            .as_ref()
-            .map(|v| PyBytes::new_bound(py, v).into()))
+        Ok(self.value.as_ref().map(|v| PyBytes::new(py, v).into()))
     }
 
     #[getter]
     fn old_value(&self, py: Python) -> PyResult<Option<Py<PyBytes>>> {
-        Ok(self
-            .old_value
-            .as_ref()
-            .map(|v| PyBytes::new_bound(py, v).into()))
+        Ok(self.old_value.as_ref().map(|v| PyBytes::new(py, v).into()))
     }
 
     #[getter]
     fn new_value(&self, py: Python) -> PyResult<Option<Py<PyBytes>>> {
-        Ok(self
-            .new_value
-            .as_ref()
-            .map(|v| PyBytes::new_bound(py, v).into()))
+        Ok(self.new_value.as_ref().map(|v| PyBytes::new(py, v).into()))
     }
 
     fn __repr__(&self) -> String {
@@ -576,7 +565,7 @@ impl PyDiffOperation {
 }
 
 /// Python wrapper for KvDiff
-#[pyclass(name = "KvDiff")]
+#[pyclass(name = "KvDiff", from_py_object)]
 #[derive(Clone)]
 struct PyKvDiff {
     key: Vec<u8>,
@@ -587,7 +576,7 @@ struct PyKvDiff {
 impl PyKvDiff {
     #[getter]
     fn key(&self, py: Python) -> PyResult<Py<PyBytes>> {
-        Ok(PyBytes::new_bound(py, &self.key).into())
+        Ok(PyBytes::new(py, &self.key).into())
     }
 
     #[getter]
@@ -716,7 +705,7 @@ impl PyVersionedKvStore {
         let guard = self.inner.lock();
         with_versioned_store!(guard, store, {
             match store.get(&key_vec) {
-                Some(value) => Ok(Some(PyBytes::new_bound(py, &value).into())),
+                Some(value) => Ok(Some(PyBytes::new(py, &value).into())),
                 None => Ok(None),
             }
         })
@@ -762,7 +751,7 @@ impl PyVersionedKvStore {
             let py_keys: Vec<Py<PyBytes>> = keys
                 .iter()
                 .take(MAX_KEYS_LIMIT)
-                .map(|key| PyBytes::new_bound(py, key).into())
+                .map(|key| PyBytes::new(py, key).into())
                 .collect();
 
             Ok(py_keys)
@@ -776,7 +765,7 @@ impl PyVersionedKvStore {
 
             let py_status: Vec<(Py<PyBytes>, String)> = status
                 .iter()
-                .map(|(key, status_str)| (PyBytes::new_bound(py, key).into(), status_str.clone()))
+                .map(|(key, status_str)| (PyBytes::new(py, key).into(), status_str.clone()))
                 .collect();
 
             Ok(py_status)
@@ -868,16 +857,16 @@ impl PyVersionedKvStore {
         };
 
         // Now convert to Python objects without holding the store lock
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let results: PyResult<Vec<HashMap<String, Py<PyAny>>>> = commits_data
                 .into_iter()
                 .map(|(id, author, committer, message, timestamp)| {
                     let mut map = HashMap::new();
-                    map.insert("id".to_string(), id.into_py(py));
-                    map.insert("author".to_string(), author.into_py(py));
-                    map.insert("committer".to_string(), committer.into_py(py));
-                    map.insert("message".to_string(), message.into_py(py));
-                    map.insert("timestamp".to_string(), timestamp.into_py(py));
+                    map.insert("id".to_string(), id.into_py_any(py).unwrap());
+                    map.insert("author".to_string(), author.into_py_any(py).unwrap());
+                    map.insert("committer".to_string(), committer.into_py_any(py).unwrap());
+                    map.insert("message".to_string(), message.into_py_any(py).unwrap());
+                    map.insert("timestamp".to_string(), timestamp.into_py_any(py).unwrap());
                     Ok(map)
                 })
                 .collect();
@@ -917,16 +906,16 @@ impl PyVersionedKvStore {
         };
 
         // Now convert to Python objects without holding the store lock
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let results: PyResult<Vec<HashMap<String, Py<PyAny>>>> = commits_data
                 .into_iter()
                 .map(|(id, author, committer, message, timestamp)| {
                     let mut map = HashMap::new();
-                    map.insert("id".to_string(), id.into_py(py));
-                    map.insert("author".to_string(), author.into_py(py));
-                    map.insert("committer".to_string(), committer.into_py(py));
-                    map.insert("message".to_string(), message.into_py(py));
-                    map.insert("timestamp".to_string(), timestamp.into_py(py));
+                    map.insert("id".to_string(), id.into_py_any(py).unwrap());
+                    map.insert("author".to_string(), author.into_py_any(py).unwrap());
+                    map.insert("committer".to_string(), committer.into_py_any(py).unwrap());
+                    map.insert("message".to_string(), message.into_py_any(py).unwrap());
+                    map.insert("timestamp".to_string(), timestamp.into_py_any(py).unwrap());
                     Ok(map)
                 })
                 .collect();
@@ -961,16 +950,16 @@ impl PyVersionedKvStore {
         };
 
         // Now convert to Python objects without holding the store lock
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let results: PyResult<Vec<HashMap<String, Py<PyAny>>>> = commits_data
                 .into_iter()
                 .map(|(id, author, committer, message, timestamp)| {
                     let mut map = HashMap::new();
-                    map.insert("id".to_string(), id.into_py(py));
-                    map.insert("author".to_string(), author.into_py(py));
-                    map.insert("committer".to_string(), committer.into_py(py));
-                    map.insert("message".to_string(), message.into_py(py));
-                    map.insert("timestamp".to_string(), timestamp.into_py(py));
+                    map.insert("id".to_string(), id.into_py_any(py).unwrap());
+                    map.insert("author".to_string(), author.into_py_any(py).unwrap());
+                    map.insert("committer".to_string(), committer.into_py_any(py).unwrap());
+                    map.insert("message".to_string(), message.into_py_any(py).unwrap());
+                    map.insert("timestamp".to_string(), timestamp.into_py_any(py).unwrap());
                     Ok(map)
                 })
                 .collect();
@@ -1069,17 +1058,17 @@ impl PyVersionedKvStore {
     fn generate_proof(&self, py: Python, key: &Bound<'_, PyBytes>) -> PyResult<Py<PyBytes>> {
         let key_vec = key.as_bytes().to_vec();
 
-        let proof_bytes = py.allow_threads(|| {
+        let proof_bytes = py.detach(|| {
             let guard = self.inner.lock();
             with_versioned_store!(guard, store, {
                 let proof = store.generate_proof(&key_vec);
-                bincode::serialize(&proof).map_err(|e| {
+                crate::serde_bincode::serialize(&proof).map_err(|e| {
                     PyValueError::new_err(format!("Proof serialization failed: {}", e))
                 })
             })
         })?;
 
-        Ok(PyBytes::new_bound(py, &proof_bytes).into())
+        Ok(PyBytes::new(py, &proof_bytes).into())
     }
 
     #[pyo3(signature = (proof_bytes, key, expected_value=None))]
@@ -1094,10 +1083,11 @@ impl PyVersionedKvStore {
         let proof_vec = proof_bytes.as_bytes().to_vec();
         let value_option = expected_value.map(|v| v.as_bytes().to_vec());
 
-        py.allow_threads(|| {
-            let proof: crate::proof::Proof<32> = bincode::deserialize(&proof_vec).map_err(|e| {
-                PyValueError::new_err(format!("Proof deserialization failed: {}", e))
-            })?;
+        py.detach(|| {
+            let proof: crate::proof::Proof<32> = crate::serde_bincode::deserialize(&proof_vec)
+                .map_err(|e| {
+                    PyValueError::new_err(format!("Proof deserialization failed: {}", e))
+                })?;
 
             let guard = self.inner.lock();
             with_versioned_store!(guard, store, {
@@ -1133,8 +1123,8 @@ impl PyVersionedKvStore {
                 .take(MAX_KEYS_LIMIT)
                 .map(|(key, value): (Vec<u8>, Vec<u8>)| {
                     (
-                        PyBytes::new_bound(py, &key).into(),
-                        PyBytes::new_bound(py, &value).into(),
+                        PyBytes::new(py, &key).into(),
+                        PyBytes::new(py, &value).into(),
                     )
                 })
                 .collect();
@@ -1244,12 +1234,18 @@ impl PyWorktreeManager {
             .add_worktree(path, &branch, create_branch)
             .map_err(|e| PyValueError::new_err(format!("Failed to add worktree: {}", e)))?;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::new();
-            map.insert("id".to_string(), info.id.into_py(py));
-            map.insert("path".to_string(), info.path.to_string_lossy().into_py(py));
-            map.insert("branch".to_string(), info.branch.into_py(py));
-            map.insert("is_linked".to_string(), info.is_linked.into_py(py));
+            map.insert("id".to_string(), info.id.into_py_any(py).unwrap());
+            map.insert(
+                "path".to_string(),
+                info.path.to_string_lossy().into_py_any(py).unwrap(),
+            );
+            map.insert("branch".to_string(), info.branch.into_py_any(py).unwrap());
+            map.insert(
+                "is_linked".to_string(),
+                info.is_linked.into_py_any(py).unwrap(),
+            );
             Ok(map)
         })
     }
@@ -1282,15 +1278,24 @@ impl PyWorktreeManager {
         let manager = self.inner.lock();
         let worktrees = manager.list_worktrees();
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let results: Vec<HashMap<String, Py<PyAny>>> = worktrees
                 .iter()
                 .map(|info| {
                     let mut map = HashMap::new();
-                    map.insert("id".to_string(), info.id.clone().into_py(py));
-                    map.insert("path".to_string(), info.path.to_string_lossy().into_py(py));
-                    map.insert("branch".to_string(), info.branch.clone().into_py(py));
-                    map.insert("is_linked".to_string(), info.is_linked.into_py(py));
+                    map.insert("id".to_string(), info.id.clone().into_py_any(py).unwrap());
+                    map.insert(
+                        "path".to_string(),
+                        info.path.to_string_lossy().into_py_any(py).unwrap(),
+                    );
+                    map.insert(
+                        "branch".to_string(),
+                        info.branch.clone().into_py_any(py).unwrap(),
+                    );
+                    map.insert(
+                        "is_linked".to_string(),
+                        info.is_linked.into_py_any(py).unwrap(),
+                    );
                     map
                 })
                 .collect();
@@ -1466,7 +1471,7 @@ impl PyWorktreeVersionedKvStore {
 /// Python is single-threaded (GIL), Rust storage is synchronous, and GlueSQL
 /// requires an async runtime. The bridging pattern used here is:
 ///
-/// 1. `py.allow_threads()` — releases the Python GIL so other Python threads
+/// 1. `py.detach()` — releases the Python GIL so other Python threads
 ///    can run while Rust executes.
 /// 2. A **per-call** `tokio::runtime::Runtime` is created inside the
 ///    GIL-free closure. A per-call runtime avoids lifetime issues with
@@ -1475,16 +1480,16 @@ impl PyWorktreeVersionedKvStore {
 /// 3. `runtime.block_on(async { ... })` drives the GlueSQL async execution,
 ///    which internally uses `spawn_blocking` for the underlying sync store
 ///    operations.
-/// 4. `Python::with_gil()` re-acquires the GIL to construct Python return
+/// 4. `Python::attach()` re-acquires the GIL to construct Python return
 ///    values.
 ///
 /// ```text
 /// Python call (GIL held)
-///   └─ py.allow_threads (GIL released)
+///   └─ py.detach (GIL released)
 ///        └─ tokio::runtime::Runtime::new()
 ///             └─ runtime.block_on(async { glue.execute(...).await })
 ///                  └─ GlueSQL → ProllyStorage → spawn_blocking → sync store
-///                       └─ Python::with_gil() → return PyObject
+///                       └─ Python::attach() → return PyObject
 /// ```
 #[cfg(feature = "sql")]
 #[pyclass(name = "ProllySQLStore")]
@@ -1523,7 +1528,7 @@ impl PyProllySQLStore {
 
     #[pyo3(signature = (query, format="dict"))]
     fn execute(&self, py: Python, query: String, format: &str) -> PyResult<Py<PyAny>> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
@@ -1541,15 +1546,15 @@ impl PyProllySQLStore {
                     .next()
                     .ok_or_else(|| PyValueError::new_err("No result from SQL query"))?;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     match result {
                         Payload::Select { labels, rows } => {
                             match format {
                                 "dict" | "dicts" => {
                                     // Return list of dictionaries
-                                    let py_list = PyList::empty_bound(py);
+                                    let py_list = PyList::empty(py);
                                     for row in rows {
-                                        let dict = PyDict::new_bound(py);
+                                        let dict = PyDict::new(py);
                                         for (i, value) in row.iter().enumerate() {
                                             if i < labels.len() {
                                                 let py_value = sql_value_to_python(py, value)?;
@@ -1562,14 +1567,14 @@ impl PyProllySQLStore {
                                 }
                                 "tuples" => {
                                     // Return (labels, rows) tuple
-                                    let py_labels = PyList::empty_bound(py);
+                                    let py_labels = PyList::empty(py);
                                     for label in &labels {
                                         py_labels.append(label)?;
                                     }
 
-                                    let py_rows = PyList::empty_bound(py);
+                                    let py_rows = PyList::empty(py);
                                     for row in rows {
-                                        let py_row = PyList::empty_bound(py);
+                                        let py_row = PyList::empty(py);
                                         for value in row {
                                             let py_value = sql_value_to_python(py, &value)?;
                                             py_row.append(py_value)?;
@@ -1577,7 +1582,7 @@ impl PyProllySQLStore {
                                         py_rows.append(py_row)?;
                                     }
 
-                                    Ok((py_labels, py_rows).into_py(py))
+                                    Ok((py_labels, py_rows).into_py_any(py).unwrap())
                                 }
                                 "json" => {
                                     // Return JSON string
@@ -1599,7 +1604,7 @@ impl PyProllySQLStore {
                                                 e
                                             ))
                                         })?;
-                                    Ok(json_str.into_py(py))
+                                    Ok(json_str.into_py_any(py).unwrap())
                                 }
                                 "csv" => {
                                     // Return CSV string
@@ -1619,7 +1624,7 @@ impl PyProllySQLStore {
                                         csv_str.push_str(&row_strs.join(","));
                                         csv_str.push('\n');
                                     }
-                                    Ok(csv_str.into_py(py))
+                                    Ok(csv_str.into_py_any(py).unwrap())
                                 }
                                 _ => Err(PyValueError::new_err(format!(
                                     "Unknown format: {}. Use 'dict', 'tuples', 'json', or 'csv'",
@@ -1628,43 +1633,43 @@ impl PyProllySQLStore {
                             }
                         }
                         Payload::Insert(count) => {
-                            let dict = PyDict::new_bound(py);
+                            let dict = PyDict::new(py);
                             dict.set_item("type", "insert")?;
                             dict.set_item("count", count)?;
                             Ok(dict.into())
                         }
                         Payload::Update(count) => {
-                            let dict = PyDict::new_bound(py);
+                            let dict = PyDict::new(py);
                             dict.set_item("type", "update")?;
                             dict.set_item("count", count)?;
                             Ok(dict.into())
                         }
                         Payload::Delete(count) => {
-                            let dict = PyDict::new_bound(py);
+                            let dict = PyDict::new(py);
                             dict.set_item("type", "delete")?;
                             dict.set_item("count", count)?;
                             Ok(dict.into())
                         }
                         Payload::Create => {
-                            let dict = PyDict::new_bound(py);
+                            let dict = PyDict::new(py);
                             dict.set_item("type", "create")?;
                             dict.set_item("success", true)?;
                             Ok(dict.into())
                         }
                         Payload::DropTable(_) => {
-                            let dict = PyDict::new_bound(py);
+                            let dict = PyDict::new(py);
                             dict.set_item("type", "drop_table")?;
                             dict.set_item("success", true)?;
                             Ok(dict.into())
                         }
                         Payload::AlterTable => {
-                            let dict = PyDict::new_bound(py);
+                            let dict = PyDict::new(py);
                             dict.set_item("type", "alter_table")?;
                             dict.set_item("success", true)?;
                             Ok(dict.into())
                         }
                         _ => {
-                            let dict = PyDict::new_bound(py);
+                            let dict = PyDict::new(py);
                             dict.set_item("type", "success")?;
                             dict.set_item("success", true)?;
                             Ok(dict.into())
@@ -1685,7 +1690,7 @@ impl PyProllySQLStore {
     }
 
     fn commit(&self, py: Python, _message: String) -> PyResult<String> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let runtime = tokio::runtime::Runtime::new()
                 .map_err(|e| PyValueError::new_err(format!("Failed to create runtime: {}", e)))?;
 
@@ -1733,7 +1738,7 @@ impl PyProllySQLStore {
         for row in values {
             let mut row_values = Vec::new();
             for value in row {
-                let value_str = Python::with_gil(|py| -> PyResult<String> {
+                let value_str = Python::attach(|py| -> PyResult<String> {
                     if let Ok(s) = value.extract::<String>(py) {
                         Ok(format!("'{}'", s.replace('\'', "''")))
                     } else if let Ok(i) = value.extract::<i64>(py) {
@@ -1786,28 +1791,28 @@ impl PyProllySQLStore {
 fn sql_value_to_python(py: Python, value: &SqlValue) -> PyResult<Py<PyAny>> {
     match value {
         SqlValue::Null => Ok(py.None()),
-        SqlValue::Bool(b) => Ok(b.into_py(py)),
-        SqlValue::I8(i) => Ok(i.into_py(py)),
-        SqlValue::I16(i) => Ok(i.into_py(py)),
-        SqlValue::I32(i) => Ok(i.into_py(py)),
-        SqlValue::I64(i) => Ok(i.into_py(py)),
-        SqlValue::I128(i) => Ok(i.into_py(py)),
-        SqlValue::U8(i) => Ok(i.into_py(py)),
-        SqlValue::U16(i) => Ok(i.into_py(py)),
-        SqlValue::U32(i) => Ok(i.into_py(py)),
-        SqlValue::U64(i) => Ok(i.into_py(py)),
-        SqlValue::U128(i) => Ok(i.to_string().into_py(py)),
-        SqlValue::F32(f) => Ok(f.into_py(py)),
-        SqlValue::F64(f) => Ok(f.into_py(py)),
-        SqlValue::Str(s) => Ok(s.into_py(py)),
-        SqlValue::Bytea(b) => Ok(PyBytes::new_bound(py, b).into()),
-        SqlValue::Date(d) => Ok(d.to_string().into_py(py)),
-        SqlValue::Time(t) => Ok(t.to_string().into_py(py)),
-        SqlValue::Timestamp(ts) => Ok(ts.to_string().into_py(py)),
-        SqlValue::Interval(i) => Ok(format!("{:?}", i).into_py(py)),
-        SqlValue::Uuid(u) => Ok(u.to_string().into_py(py)),
+        SqlValue::Bool(b) => Ok(b.into_py_any(py).unwrap()),
+        SqlValue::I8(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::I16(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::I32(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::I64(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::I128(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::U8(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::U16(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::U32(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::U64(i) => Ok(i.into_py_any(py).unwrap()),
+        SqlValue::U128(i) => Ok(i.to_string().into_py_any(py).unwrap()),
+        SqlValue::F32(f) => Ok(f.into_py_any(py).unwrap()),
+        SqlValue::F64(f) => Ok(f.into_py_any(py).unwrap()),
+        SqlValue::Str(s) => Ok(s.into_py_any(py).unwrap()),
+        SqlValue::Bytea(b) => Ok(PyBytes::new(py, b).into()),
+        SqlValue::Date(d) => Ok(d.to_string().into_py_any(py).unwrap()),
+        SqlValue::Time(t) => Ok(t.to_string().into_py_any(py).unwrap()),
+        SqlValue::Timestamp(ts) => Ok(ts.to_string().into_py_any(py).unwrap()),
+        SqlValue::Interval(i) => Ok(format!("{:?}", i).into_py_any(py).unwrap()),
+        SqlValue::Uuid(u) => Ok(u.to_string().into_py_any(py).unwrap()),
         SqlValue::Map(m) => {
-            let dict = PyDict::new_bound(py);
+            let dict = PyDict::new(py);
             for (k, v) in m.iter() {
                 let py_value = sql_value_to_python(py, v)?;
                 dict.set_item(k, py_value)?;
@@ -1815,16 +1820,16 @@ fn sql_value_to_python(py: Python, value: &SqlValue) -> PyResult<Py<PyAny>> {
             Ok(dict.into())
         }
         SqlValue::List(l) => {
-            let py_list = PyList::empty_bound(py);
+            let py_list = PyList::empty(py);
             for item in l.iter() {
                 let py_value = sql_value_to_python(py, item)?;
                 py_list.append(py_value)?;
             }
             Ok(py_list.into())
         }
-        SqlValue::Decimal(d) => Ok(d.to_string().into_py(py)),
-        SqlValue::Point(p) => Ok(format!("POINT({} {})", p.x, p.y).into_py(py)),
-        SqlValue::Inet(ip) => Ok(ip.to_string().into_py(py)),
+        SqlValue::Decimal(d) => Ok(d.to_string().into_py_any(py).unwrap()),
+        SqlValue::Point(p) => Ok(format!("POINT({} {})", p.x, p.y).into_py_any(py).unwrap()),
+        SqlValue::Inet(ip) => Ok(ip.to_string().into_py_any(py).unwrap()),
     }
 }
 
@@ -1947,7 +1952,7 @@ impl PyNamespacedKvStore {
         Ok(store
             .namespace(namespace)
             .get(key.as_bytes())
-            .map(|v| PyBytes::new_bound(py, &v).into()))
+            .map(|v| PyBytes::new(py, &v).into()))
     }
 
     /// Delete a key from a specific namespace.
@@ -1963,11 +1968,8 @@ impl PyNamespacedKvStore {
     fn ns_list_keys<'py>(&self, py: Python<'py>, namespace: &str) -> PyResult<Py<PyList>> {
         let mut store = self.inner.lock();
         let keys = store.namespace(namespace).list_keys();
-        let py_keys: Vec<Py<PyBytes>> = keys
-            .iter()
-            .map(|k| PyBytes::new_bound(py, k).into())
-            .collect();
-        Ok(PyList::new_bound(py, &py_keys).into())
+        let py_keys: Vec<Py<PyBytes>> = keys.iter().map(|k| PyBytes::new(py, k).into()).collect();
+        Ok(PyList::new(py, &py_keys)?.into())
     }
 
     // -- Registry operations --
@@ -1994,7 +1996,7 @@ impl PyNamespacedKvStore {
         self.inner
             .lock()
             .get_namespace_root_hash(namespace)
-            .map(|h| PyBytes::new_bound(py, h.as_bytes()).into())
+            .map(|h| PyBytes::new(py, h.as_bytes()).into())
     }
 
     /// Check if a namespace changed between two commits.
@@ -2025,7 +2027,7 @@ impl PyNamespacedKvStore {
             .inner
             .lock()
             .get(key.as_bytes())
-            .map(|v| PyBytes::new_bound(py, &v).into()))
+            .map(|v| PyBytes::new(py, &v).into()))
     }
 
     /// Delete from the default namespace.
@@ -2039,11 +2041,8 @@ impl PyNamespacedKvStore {
     /// List keys in the default namespace.
     fn list_keys<'py>(&self, py: Python<'py>) -> PyResult<Py<PyList>> {
         let keys = self.inner.lock().list_keys();
-        let py_keys: Vec<Py<PyBytes>> = keys
-            .iter()
-            .map(|k| PyBytes::new_bound(py, k).into())
-            .collect();
-        Ok(PyList::new_bound(py, &py_keys).into())
+        let py_keys: Vec<Py<PyBytes>> = keys.iter().map(|k| PyBytes::new(py, k).into()).collect();
+        Ok(PyList::new(py, &py_keys)?.into())
     }
 
     // -- Git operations --
@@ -2209,18 +2208,18 @@ impl PyNamespacedKvStore {
         };
         let tuples: Vec<Py<PyAny>> = hits
             .into_iter()
-            .map(|h| {
-                let t = pyo3::types::PyTuple::new_bound(
+            .map(|h| -> PyResult<Py<PyAny>> {
+                let t = pyo3::types::PyTuple::new(
                     py,
                     &[
-                        PyBytes::new_bound(py, &h.id).to_object(py),
-                        h.score.to_object(py),
+                        PyBytes::new(py, &h.id).into_py_any(py)?,
+                        h.score.into_py_any(py)?,
                     ],
-                );
-                t.into()
+                )?;
+                Ok(t.into())
             })
-            .collect();
-        Ok(PyList::new_bound(py, &tuples).into())
+            .collect::<PyResult<Vec<_>>>()?;
+        Ok(PyList::new(py, &tuples)?.into())
     }
 
     /// Delete every chunk for `id` from a text sub-index.
@@ -2316,19 +2315,19 @@ impl PyNamespacedKvStore {
             .lock()
             .audit_text_index(namespace, idx_name)
             .map_err(|e| PyValueError::new_err(format!("audit_text_index failed: {e}")))?;
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
         let orphans: Vec<Py<PyBytes>> = report
             .orphans_in_index
             .iter()
-            .map(|b| PyBytes::new_bound(py, b).into())
+            .map(|b| PyBytes::new(py, b).into())
             .collect();
         let missing: Vec<Py<PyBytes>> = report
             .missing_from_index
             .iter()
-            .map(|b| PyBytes::new_bound(py, b).into())
+            .map(|b| PyBytes::new(py, b).into())
             .collect();
-        d.set_item("orphans_in_index", PyList::new_bound(py, &orphans))?;
-        d.set_item("missing_from_index", PyList::new_bound(py, &missing))?;
+        d.set_item("orphans_in_index", PyList::new(py, &orphans)?)?;
+        d.set_item("missing_from_index", PyList::new(py, &missing)?)?;
         d.set_item("is_in_sync", report.is_in_sync())?;
         Ok(d.into())
     }
@@ -2364,7 +2363,7 @@ impl PyNamespacedKvStore {
             .lock()
             .gc_blobs()
             .map_err(|e| PyValueError::new_err(format!("gc_blobs failed: {e}")))?;
-        let d = PyDict::new_bound(py);
+        let d = PyDict::new(py);
         d.set_item("total", report.total)?;
         d.set_item("referenced", report.referenced)?;
         d.set_item("removed", report.removed)?;
@@ -2523,7 +2522,7 @@ impl Embedder for CallableEmbedderImpl {
         self.dim
     }
     fn embed(&self, text: &str) -> Result<Vec<f32>, crate::proximity::EmbedError> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let result = self.callable.bind(py).call1((text,)).map_err(|e| {
                 crate::proximity::EmbedError::Failure(format!("python callback raised: {e}"))
             })?;
@@ -2598,14 +2597,14 @@ impl PyCallableEmbedder {
 /// known Python embedder wrappers.
 #[cfg(feature = "proximity")]
 fn extract_embedder(obj: &Bound<'_, PyAny>) -> PyResult<Arc<dyn Embedder>> {
-    if let Ok(h) = obj.downcast::<PyHashEmbedder>() {
+    if let Ok(h) = obj.cast::<PyHashEmbedder>() {
         return Ok(h.borrow().inner.clone());
     }
-    if let Ok(c) = obj.downcast::<PyCallableEmbedder>() {
+    if let Ok(c) = obj.cast::<PyCallableEmbedder>() {
         return Ok(c.borrow().inner.clone());
     }
     #[cfg(feature = "proximity_text")]
-    if let Ok(m) = obj.downcast::<PyMiniLmEmbedder>() {
+    if let Ok(m) = obj.cast::<PyMiniLmEmbedder>() {
         return Ok(m.borrow().inner.clone());
     }
     Err(PyValueError::new_err(

--- a/src/rocksdb/storage.rs
+++ b/src/rocksdb/storage.rs
@@ -153,7 +153,7 @@ impl<const N: usize> NodeStorage<N> for RocksDBNodeStorage<N> {
         match self.db.get(&key) {
             Ok(Some(data)) => {
                 // split/merged are #[serde(skip)] so they deserialize as false.
-                match bincode::deserialize::<ProllyNode<N>>(&data) {
+                match crate::serde_bincode::deserialize::<ProllyNode<N>>(&data) {
                     Ok(node) => {
                         let node = Arc::new(node);
 
@@ -178,7 +178,7 @@ impl<const N: usize> NodeStorage<N> for RocksDBNodeStorage<N> {
         self.cache.lock().put(hash.clone(), Arc::new(node.clone()));
 
         // Serialize and store in RocksDB
-        let data = bincode::serialize(&node)?;
+        let data = crate::serde_bincode::serialize(&node)?;
         let key = Self::node_key(&hash);
         self.db
             .put(&key, data)
@@ -270,7 +270,7 @@ impl<const N: usize> RocksDBNodeStorage<N> {
             cache.put(hash.clone(), Arc::new(node.clone()));
 
             // Add to batch
-            match bincode::serialize(&node) {
+            match crate::serde_bincode::serialize(&node) {
                 Ok(data) => {
                     let key = Self::node_key(&hash);
                     batch.put(&key, data);

--- a/src/serde_bincode.rs
+++ b/src/serde_bincode.rs
@@ -1,0 +1,39 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Thin wrappers around bincode 2.x that preserve the bincode 1.x wire format
+//! and 1.x-style `serialize`/`deserialize` ergonomics for existing call sites.
+//!
+//! The on-disk format produced by [`serialize`] is byte-compatible with
+//! bincode 1.3's default config (fixed-int, little-endian, no length limit) so
+//! existing git blobs, RocksDB rows, and proximity index snapshots written by
+//! older versions of this crate continue to round-trip.
+
+use bincode::error::{DecodeError, EncodeError};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+#[inline]
+fn config() -> impl bincode::config::Config {
+    bincode::config::legacy()
+}
+
+pub fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, EncodeError> {
+    bincode::serde::encode_to_vec(value, config())
+}
+
+pub fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, DecodeError> {
+    let (value, _read) = bincode::serde::decode_from_slice(bytes, config())?;
+    Ok(value)
+}

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -75,7 +75,7 @@ impl<const N: usize> NodeStorage<N> for FileNodeStorage<N> {
             let mut data = Vec::new();
             file.read_to_end(&mut data).ok()?;
             // split/merged are #[serde(skip)] so they deserialize as false.
-            let node: ProllyNode<N> = bincode::deserialize(&data).ok()?;
+            let node: ProllyNode<N> = crate::serde_bincode::deserialize(&data).ok()?;
             Some(Arc::new(node))
         } else {
             None
@@ -88,7 +88,7 @@ impl<const N: usize> NodeStorage<N> for FileNodeStorage<N> {
         node: ProllyNode<N>,
     ) -> Result<(), StorageError> {
         let path = self.node_path(&hash);
-        let data = bincode::serialize(&node)?;
+        let data = crate::serde_bincode::serialize(&node)?;
         let mut file = File::create(path)?;
         file.write_all(&data)?;
         Ok(())

--- a/src/storage/git.rs
+++ b/src/storage/git.rs
@@ -144,7 +144,7 @@ impl<const N: usize> GitNodeStorage<N> {
 
     /// Store a node as a Git blob
     fn store_node_as_blob(&self, node: &ProllyNode<N>) -> Result<gix::ObjectId, GitKvError> {
-        let serialized = bincode::serialize(node)?;
+        let serialized = crate::serde_bincode::serialize(node)?;
 
         // Write the serialized node as a Git blob
         let repo = self._repository.lock();
@@ -168,8 +168,8 @@ impl<const N: usize> GitNodeStorage<N> {
         })?;
 
         // Deserialize the blob data back to a ProllyNode
-        let node: ProllyNode<N> =
-            bincode::deserialize(object.data).map_err(GitKvError::SerializationError)?;
+        let node: ProllyNode<N> = crate::serde_bincode::deserialize(object.data)
+            .map_err(GitKvError::SerializationDecodeError)?;
 
         Ok(node)
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -39,9 +39,13 @@ pub enum StorageError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// A serialization or deserialization error occurred.
-    #[error("Serialization error: {0}")]
-    Serialization(#[from] bincode::Error),
+    /// A serialization error occurred while encoding a value.
+    #[error("Serialization encode error: {0}")]
+    SerializationEncode(#[from] bincode::error::EncodeError),
+
+    /// A deserialization error occurred while decoding bytes.
+    #[error("Serialization decode error: {0}")]
+    SerializationDecode(#[from] bincode::error::DecodeError),
 
     /// A storage-specific error with a descriptive message.
     #[error("Storage error: {0}")]


### PR DESCRIPTION
## Summary

Combined dependency upgrade that supersedes the open Dependabot PRs:

- Closes #172 (assert_cmd 2.0 → 2.2)
- Closes #173 (bincode 1.3.3 → ~~3.0.0~~ 2.0; see note below)
- Closes #174 (uuid 1.21 → 1.23)
- Closes #175 (lru 0.16 → 0.18)
- Closes #176 (pyo3 0.22 → 0.28)

## What changed

### pyo3 0.22 → 0.28
- `PyBytes::new_bound` / `PyDict::new_bound` / `PyList::new_bound` / `PyList::empty_bound` → unsuffixed `new` / `empty` (the `Bound` variants became the default).
- `PyList::new` is now fallible (returns `PyResult`), so call sites add `?`.
- `py.allow_threads(..)` → `py.detach(..)` and `Python::with_gil(..)` → `Python::attach(..)` (0.28 rename).
- `value.into_py(py)` → `value.into_py_any(py).unwrap()` via the new `IntoPyObjectExt` trait.
- `obj.downcast::<T>()` → `obj.cast::<T>()` on `&Bound<PyAny>`.
- Five `#[pyclass]` types that derive `Clone` opt in to the legacy `FromPyObject` derive via `from_py_object` to silence the 0.28 deprecation warning.

### bincode 1.3.3 → 2.0
**Note:** Dependabot's #173 proposed `bincode 3.0.0`, but that release is an xkcd-2347 placeholder crate (`compile_error!("https://xkcd.com/2347/");`) — not a real release. This PR targets `bincode 2.0.1`, the actual latest stable.

- New `crate::serde_bincode` helper module wraps `bincode::serde::encode_to_vec` / `decode_from_slice` with `bincode::config::legacy()`, preserving byte-level wire compatibility with bincode 1.3. **Existing git blobs, RocksDB rows, and proximity index snapshots written by older versions still round-trip.**
- `bincode::Error` is gone in 2.x. `GitKvError::SerializationError` splits into `SerializationEncodeError(EncodeError)` / `SerializationDecodeError(DecodeError)`; `StorageError::Serialization` likewise splits into `SerializationEncode` / `SerializationDecode`.

### lru 0.16 → 0.18, uuid 1.0 → 1.23, assert_cmd 2.0 → 2.2
Drop-in — no code changes needed.

## Test plan

- [x] `cargo build --all` clean
- [x] `cargo clippy --features "git sql"` clean
- [x] `cargo clippy --features "git sql rocksdb_storage proximity proximity_text"` clean
- [x] `cargo clippy --features "python proximity proximity_text rocksdb_storage"` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --features "git sql"` — 225 tests pass, 0 failed
- [x] `cargo test --features "git sql rocksdb_storage proximity proximity_text"` — 363 tests pass, 0 failed
- [x] `maturin build --release --features "python sql"` produces a working wheel
- [x] Smoke-test wheel: `ProllyTree.insert`/`find` round-trip works
- [x] `pytest python/tests/` (without rocksdb-gated tests) — 21 of 22 collected tests pass; the 1 setup error in `test_sql.py` is pre-existing (test creates a `tempfile.mkdtemp()` and calls `ProllySQLStore(dir)` without `git init` first — fails on `main` as well).