### PR TITLE
fix(diff): repair data-loss in diff_nodes_recursive (canonical O(differences) structural diff)

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -865,7 +865,146 @@ impl<const N: usize, S: NodeStorage<N>> ProllyTree<N, S> {
         new_node: &ProllyNode<N>,
         diffs: &mut Vec<DiffResult>,
     ) {
-        self.diff_recursive(old_node, new_node, diffs);
+        // O(differences) structural diff (Dolt/Noms): the tree is content-addressed,
+        // so equal get_hash() => byte-identical subtree => zero diffs; skip it without
+        // loading. Descend only into differing children. Emits the IDENTICAL DiffResult
+        // set as the full-leaf flatten (diff_nodes_flatten), guarded by a differential test.
+        if old_node.get_hash() == new_node.get_hash() {
+            return;
+        }
+        match (old_node.is_leaf, new_node.is_leaf) {
+            (true, true) => {
+                let o: Vec<(Vec<u8>, Vec<u8>)> = old_node
+                    .keys
+                    .iter()
+                    .cloned()
+                    .zip(old_node.values.iter().cloned())
+                    .collect();
+                let n: Vec<(Vec<u8>, Vec<u8>)> = new_node
+                    .keys
+                    .iter()
+                    .cloned()
+                    .zip(new_node.values.iter().cloned())
+                    .collect();
+                self.merge_join_pairs(&o, &n, diffs);
+            }
+            (false, false) => self.diff_internal(old_node, new_node, diffs),
+            _ => {
+                // height divergence (one side shallower): flatten the divergent region.
+                let mut op = Vec::new();
+                self.collect_pairs_recursive(old_node, &mut op);
+                let mut np = Vec::new();
+                self.collect_pairs_recursive(new_node, &mut np);
+                self.merge_join_pairs(&op, &np, diffs);
+            }
+        }
+    }
+
+    /// Both nodes internal: skip children whose stored child-hash is equal (O(1), no
+    /// load), flatten + merge-join the rest. Provably identical to the full flatten:
+    /// a common child subtree has identical (k,v) on both sides => contributes no diff.
+    fn diff_internal(
+        &self,
+        old_node: &ProllyNode<N>,
+        new_node: &ProllyNode<N>,
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        use std::collections::HashSet;
+        // The node is content-addressed: an internal node's `values` ARE its child
+        // hashes, so byte-equal `values[i]` <=> identical child subtree (same (k,v)).
+        // Skip common children by hash WITHOUT loading them (the O(diff) win), and
+        // load only the differing children (mirroring `children()`'s raw_hash lookup).
+        let new_hashes: HashSet<&Vec<u8>> = new_node.values.iter().collect();
+        let old_hashes: HashSet<&Vec<u8>> = old_node.values.iter().collect();
+        let mut old_pairs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for child_hash in &old_node.values {
+            if new_hashes.contains(child_hash) {
+                continue; // identical subtree on the new side => contributes no diff
+            }
+            if let Some(child) = self
+                .storage
+                .get_node_by_hash(&ValueDigest::raw_hash(child_hash))
+            {
+                self.collect_pairs_recursive(&child, &mut old_pairs);
+            }
+        }
+        let mut new_pairs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for child_hash in &new_node.values {
+            if old_hashes.contains(child_hash) {
+                continue;
+            }
+            if let Some(child) = self
+                .storage
+                .get_node_by_hash(&ValueDigest::raw_hash(child_hash))
+            {
+                self.collect_pairs_recursive(&child, &mut new_pairs);
+            }
+        }
+        self.merge_join_pairs(&old_pairs, &new_pairs, diffs);
+    }
+
+    /// Merge-join two sorted (key,value) streams into DiffResults.
+    fn merge_join_pairs(
+        &self,
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        let mut oi = old_pairs.iter().peekable();
+        let mut ni = new_pairs.iter().peekable();
+        while let (Some((ok, ov)), Some((nk, nv))) = (oi.peek(), ni.peek()) {
+            match ok.cmp(nk) {
+                std::cmp::Ordering::Less => {
+                    diffs.push(DiffResult::Removed(ok.clone(), ov.clone()));
+                    oi.next();
+                }
+                std::cmp::Ordering::Greater => {
+                    diffs.push(DiffResult::Added(nk.clone(), nv.clone()));
+                    ni.next();
+                }
+                std::cmp::Ordering::Equal => {
+                    if ov != nv {
+                        diffs.push(DiffResult::Modified(ok.clone(), ov.clone(), nv.clone()));
+                    }
+                    oi.next();
+                    ni.next();
+                }
+            }
+        }
+        for (ok, ov) in oi {
+            diffs.push(DiffResult::Removed(ok.clone(), ov.clone()));
+        }
+        for (nk, nv) in ni {
+            diffs.push(DiffResult::Added(nk.clone(), nv.clone()));
+        }
+    }
+
+    /// Proven full-leaf flatten diff — kept as the differential-test oracle.
+    #[cfg(test)]
+    fn diff_nodes_flatten(
+        &self,
+        old_node: &ProllyNode<N>,
+        new_node: &ProllyNode<N>,
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        let mut old_pairs = Vec::new();
+        self.collect_pairs_recursive(old_node, &mut old_pairs);
+        let mut new_pairs = Vec::new();
+        self.collect_pairs_recursive(new_node, &mut new_pairs);
+        self.merge_join_pairs(&old_pairs, &new_pairs, diffs);
+    }
+
+    /// Collect all leaf (key, value) pairs of a subtree in sorted order (full traversal).
+    fn collect_pairs_recursive(&self, node: &ProllyNode<N>, pairs: &mut Vec<(Vec<u8>, Vec<u8>)>) {
+        if node.is_leaf {
+            for (k, v) in node.keys.iter().zip(node.values.iter()) {
+                pairs.push((k.clone(), v.clone()));
+            }
+        } else {
+            for child in node.children(&self.storage) {
+                self.collect_pairs_recursive(&child, pairs);
+            }
+        }
     }
 
     /// Find a value for a specific key in a node tree
@@ -1005,6 +1144,7 @@ impl<const N: usize, S: NodeStorage<N>> ProllyTree<N, S> {
     /// * `old_node` - The node from the original tree.
     /// * `new_node` - The node from the new tree.
     /// * `diffs` - The vector to store the differences.
+    #[allow(dead_code)]
     fn diff_recursive(
         &self,
         old_node: &ProllyNode<N>,
@@ -2642,3 +2782,302 @@ mod tests {
         }
     }
 }
+
+/// O(diff) structural-diff differential tests: the structural `diff_nodes_recursive`
+/// must emit a BYTE-IDENTICAL `Vec<DiffResult>` to the proven full-leaf flatten oracle
+/// (`diff_nodes_flatten`) on every shape — and load strictly fewer nodes when a large
+/// subtree is shared. prollytree is history-independent, so shape is a function of
+/// CONTENT; divergent shapes come from divergent content with a shared region.
+#[cfg(test)]
+mod odiff_differential {
+    use super::*;
+    use crate::digest::ValueDigest;
+    use crate::storage::{InMemoryNodeStorage, NodeStorage, StorageError};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// InMemoryNodeStorage wrapper that counts `get_node_by_hash` (node loads).
+    #[derive(Clone)]
+    struct CountingStorage<const N: usize> {
+        inner: InMemoryNodeStorage<N>,
+        loads: Arc<AtomicUsize>,
+    }
+    impl<const N: usize> CountingStorage<N> {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryNodeStorage::<N>::default(),
+                loads: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+    impl<const N: usize> NodeStorage<N> for CountingStorage<N> {
+        fn get_node_by_hash(&self, hash: &ValueDigest<N>) -> Option<Arc<ProllyNode<N>>> {
+            self.loads.fetch_add(1, Ordering::SeqCst);
+            self.inner.get_node_by_hash(hash)
+        }
+        fn insert_node(
+            &mut self,
+            hash: ValueDigest<N>,
+            node: ProllyNode<N>,
+        ) -> Result<(), StorageError> {
+            self.inner.insert_node(hash, node)
+        }
+        fn delete_node(&mut self, hash: &ValueDigest<N>) -> Result<(), StorageError> {
+            self.inner.delete_node(hash)
+        }
+        fn save_config(&self, key: &str, config: &[u8]) {
+            self.inner.save_config(key, config)
+        }
+        fn get_config(&self, key: &str) -> Option<Vec<u8>> {
+            self.inner.get_config(key)
+        }
+    }
+
+    /// Build BOTH trees into ONE storage. `InMemoryNodeStorage::clone` DEEP-COPIES the
+    /// node map and `insert` persists nodes into the TREE's storage — so we must thread
+    /// one storage through both builds (clone carries old's nodes forward; new's inserts
+    /// add to it) rather than clone-then-copy-only-root (which strands all children and
+    /// makes a multi-level diff trivially empty). Returns (storage_with_both, roots).
+    fn build_two(
+        config: &TreeConfig<32>,
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> (CountingStorage<32>, ValueDigest<32>, ValueDigest<32>) {
+        let mut t_old = ProllyTree::new(CountingStorage::<32>::new(), config.clone());
+        for (k, v) in old_pairs {
+            t_old.insert(k.clone(), v.clone());
+        }
+        let old_root = t_old.get_root_hash().unwrap();
+        // Ensure the root node is present even when no insert ran (empty tree:
+        // `insert`/`persist_root` never fired).
+        t_old
+            .storage
+            .insert_node(old_root.clone(), t_old.root.clone())
+            .unwrap();
+        // clone() carries a full copy of old's nodes; new's inserts add new's nodes,
+        // never evicting old's -> the result holds BOTH complete trees.
+        let mut t_new = ProllyTree::new(t_old.storage.clone(), config.clone());
+        for (k, v) in new_pairs {
+            t_new.insert(k.clone(), v.clone());
+        }
+        let new_root = t_new.get_root_hash().unwrap();
+        t_new
+            .storage
+            .insert_node(new_root.clone(), t_new.root.clone())
+            .unwrap();
+        (t_new.storage, old_root, new_root)
+    }
+
+    /// k-th key as a fixed-width sortable 8-byte big-endian blob.
+    fn key(i: u64) -> Vec<u8> {
+        i.to_be_bytes().to_vec()
+    }
+    /// variable-length value (exercises the D14 variable-length canonicality face).
+    fn val(i: u64, tag: u8) -> Vec<u8> {
+        let mut v = vec![tag];
+        v.extend_from_slice(&i.to_le_bytes());
+        v.extend(std::iter::repeat_n(tag, (i % 19) as usize));
+        v
+    }
+
+    /// Assert structural diff == flatten oracle (exact Vec<DiffResult>), return
+    /// (structural_loads, flatten_loads) measured during the diff only.
+    fn assert_identical(
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+        label: &str,
+    ) -> (usize, usize) {
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, old_pairs, new_pairs);
+
+        // Both full trees are in `storage`; their children resolve (asserted below).
+        let old_node = storage.get_node_by_hash(&old_root).unwrap();
+        let new_node = storage.get_node_by_hash(&new_root).unwrap();
+        // HARNESS GUARD: a non-leaf root's children MUST resolve, else the diff would
+        // be trivially empty (the build_root bug). children() returns all present.
+        if !old_node.is_leaf {
+            assert_eq!(
+                old_node.children(&storage).len(),
+                old_node.values.len(),
+                "[{label}] old root children not all persisted (harness bug)"
+            );
+        }
+        if !new_node.is_leaf {
+            assert_eq!(
+                new_node.children(&storage).len(),
+                new_node.values.len(),
+                "[{label}] new root children not all persisted (harness bug)"
+            );
+        }
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+
+        storage.loads.store(0, Ordering::SeqCst);
+        let mut d_struct = Vec::new();
+        facade.diff_nodes_recursive(&old_node, &new_node, &mut d_struct);
+        let struct_loads = storage.loads.load(Ordering::SeqCst);
+
+        storage.loads.store(0, Ordering::SeqCst);
+        let mut d_flat = Vec::new();
+        facade.diff_nodes_flatten(&old_node, &new_node, &mut d_flat);
+        let flat_loads = storage.loads.load(Ordering::SeqCst);
+
+        assert_eq!(
+            d_struct, d_flat,
+            "[{label}] structural diff diverged from flatten oracle"
+        );
+        (struct_loads, flat_loads)
+    }
+
+    fn range_pairs(lo: u64, hi: u64, tag: u8) -> Vec<(Vec<u8>, Vec<u8>)> {
+        (lo..hi).map(|i| (key(i), val(i, tag))).collect()
+    }
+
+    #[test]
+    fn identical_trees_zero_diff_zero_descent() {
+        let base = range_pairs(0, 1000, 0);
+        let (s, f) = assert_identical(&base, &base, "identical");
+        // equal root hash => structural returns immediately, no descent at all.
+        assert_eq!(s, 0, "identical trees must load zero nodes structurally");
+        assert!(f >= s);
+    }
+
+    #[test]
+    fn localized_modify_skips_shared_subtrees() {
+        let old = range_pairs(0, 1000, 0);
+        let mut new = old.clone();
+        new[500].1 = val(500, 9); // one cell changed deep in the tree
+        let (s, f) = assert_identical(&old, &new, "localized_modify");
+        assert!(
+            s < f,
+            "localized change must load fewer nodes structurally ({s}) than flatten ({f})"
+        );
+        // GROUND TRUTH (not just structural==flatten): the diff must be EXACTLY the one
+        // changed cell — guards against a both-paths-lossy false pass.
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, &old, &new);
+        let on = storage.get_node_by_hash(&old_root).unwrap();
+        let nn = storage.get_node_by_hash(&new_root).unwrap();
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+        let mut d = Vec::new();
+        facade.diff_nodes_recursive(&on, &nn, &mut d);
+        assert_eq!(
+            d,
+            vec![DiffResult::Modified(key(500), val(500, 0), val(500, 9))],
+            "structural diff must report exactly the one changed cell, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn bulk_suffix_add_shares_prefix() {
+        let old = range_pairs(0, 800, 0);
+        let new = range_pairs(0, 1000, 0); // 200 appended at the high end
+        let (s, f) = assert_identical(&old, &new, "bulk_suffix_add");
+        assert!(
+            s < f,
+            "shared-prefix add should skip prefix subtrees ({s} < {f})"
+        );
+    }
+
+    #[test]
+    fn bulk_prefix_remove() {
+        let old = range_pairs(0, 1000, 0);
+        let new = range_pairs(200, 1000, 0); // low 200 removed
+        assert_identical(&old, &new, "bulk_prefix_remove");
+    }
+
+    #[test]
+    fn scattered_modifications() {
+        let old = range_pairs(0, 1000, 0);
+        let mut new = old.clone();
+        for i in (0..1000).step_by(7) {
+            new[i].1 = val(i as u64, 5); // every 7th cell changed
+        }
+        assert_identical(&old, &new, "scattered_modify");
+    }
+
+    #[test]
+    fn fully_disjoint_keyspaces() {
+        let old = range_pairs(0, 500, 0);
+        let new = range_pairs(10_000, 10_500, 0); // no overlap at all
+        assert_identical(&old, &new, "disjoint");
+    }
+
+    #[test]
+    fn interleaved_add_remove_modify() {
+        let mut old = range_pairs(0, 600, 0);
+        // remove evens, modify multiples of 3, keep odds; then add a high block.
+        let mut new: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for i in 0..600u64 {
+            if i % 2 == 0 {
+                continue; // removed
+            }
+            let tag = if i % 3 == 0 { 7 } else { 0 };
+            new.push((key(i), val(i, tag)));
+        }
+        new.extend(range_pairs(600, 720, 0));
+        old.sort();
+        new.sort();
+        assert_identical(&old, &new, "interleaved");
+    }
+
+    #[test]
+    fn ground_truth_add_remove_modify() {
+        // base 0..200; new: drop key 50, modify key 100, add key 500. Diff must be
+        // EXACTLY those three ops (sorted by key), regardless of structural pruning.
+        let old = range_pairs(0, 200, 0);
+        let mut new = old.clone();
+        new.retain(|(k, _)| k != &key(50));
+        for p in new.iter_mut() {
+            if p.0 == key(100) {
+                p.1 = val(100, 9);
+            }
+        }
+        new.push((key(500), val(500, 0)));
+        new.sort();
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, &old, &new);
+        let on = storage.get_node_by_hash(&old_root).unwrap();
+        let nn = storage.get_node_by_hash(&new_root).unwrap();
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+        let mut d = Vec::new();
+        facade.diff_nodes_recursive(&on, &nn, &mut d);
+        // merge-join emits in key order: 50 (Removed) < 100 (Modified) < 500 (Added).
+        assert_eq!(
+            d,
+            vec![
+                DiffResult::Removed(key(50), val(50, 0)),
+                DiffResult::Modified(key(100), val(100, 0), val(100, 9)),
+                DiffResult::Added(key(500), val(500, 0)),
+            ],
+            "structural diff ground truth mismatch, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn report_load_win() {
+        for n in [1_000u64, 4_000u64] {
+            let old = range_pairs(0, n, 0);
+            let mut new = old.clone();
+            new[(n / 2) as usize].1 = val(n / 2, 9); // one cell changed
+            let (s, f) = assert_identical(&old, &new, "report");
+            eprintln!(
+                "ODIFF_LOAD_WIN n={n} one-cell-change: structural_loads={s} flatten_loads={f} ratio={:.1}x",
+                f as f64 / s.max(1) as f64
+            );
+        }
+    }
+
+    #[test]
+    fn small_multilevel_and_single_leaf() {
+        // small trees (single leaf / shallow) must also match exactly.
+        assert_identical(&range_pairs(0, 3, 0), &range_pairs(0, 5, 0), "tiny");
+        assert_identical(
+            &range_pairs(0, 1, 0),
+            &range_pairs(0, 1, 1),
+            "one_key_modify",
+        );
+        assert_identical(&[], &range_pairs(0, 4, 0), "empty_to_small");
+        assert_identical(&range_pairs(0, 4, 0), &[], "small_to_empty");
+    }
+}
+


### PR DESCRIPTION
## Bug

`ProllyTree::diff` (via `diff_nodes_recursive`) descended incorrectly and could **silently drop changes** — a data-loss diff. Because `merge()` diffs internally, this also yields incorrect/non-canonical merges for some tree shapes.

## Fix

Rewrite `diff_nodes_recursive` as a content-addressed O(differences) structural diff (Dolt/Noms style):

- equal `get_hash()` ⇒ byte-identical subtree ⇒ skip without loading;
- leaf/leaf ⇒ merge-join the `(key, value)` pairs;
- internal/internal ⇒ skip children whose stored child-hash matches (no load), flatten only the divergent region;
- height divergence ⇒ flatten the shallower side.

The old `diff_recursive` is retained (`#[allow(dead_code)]`). A `#[cfg(test)]` full-leaf flatten oracle (`diff_nodes_flatten`) is the ground truth, and the new fast path is asserted **byte-identical** to it on every shape.

## Tests

`mod odiff_differential`: differential tests (structural diff == flatten oracle) + exact ground-truth add/remove/modify assertions + load-count wins.

## Verification

`cargo test` — full suite green, **0 regressions**. No format/hash change; uses only existing APIs. Based on `main` @ `373128e`.