### PR TITLE
fix: prefix-free node hashing — distinct (k,v) sets must not collide

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1122,9 +1122,27 @@ impl<const N: usize> Node<N> for ProllyNode<N> {
 // implement get hash function of the ProllyNode
 impl<const N: usize> ProllyNode<N> {
     pub fn get_hash(&self) -> ValueDigest<N> {
-        let mut keys_and_values = self.keys.concat();
-        keys_and_values.extend(&self.values.concat());
-        ValueDigest::new(&keys_and_values)
+        // PREFIX-FREE content hash. The previous `keys.concat() ++ values.concat()`
+        // had no length delimiters, so distinct (k,v) sets could collide (e.g. values
+        // "ab","c" and "a","bc" both concat to "abc") -> same root -> broken content
+        // addressing / false merge convergence. Length-frame every element (u32 BE,
+        // never usize, for native==wasm), separate the key region from the value
+        // region by count, and bind is_leaf/level so a leaf cannot collide with an
+        // internal node of identical bytes.
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(self.is_leaf as u8);
+        buf.push(self.level);
+        buf.extend_from_slice(&(self.keys.len() as u32).to_be_bytes());
+        for k in &self.keys {
+            buf.extend_from_slice(&(k.len() as u32).to_be_bytes());
+            buf.extend_from_slice(k);
+        }
+        buf.extend_from_slice(&(self.values.len() as u32).to_be_bytes());
+        for v in &self.values {
+            buf.extend_from_slice(&(v.len() as u32).to_be_bytes());
+            buf.extend_from_slice(v);
+        }
+        ValueDigest::new(&buf)
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -2642,3 +2642,32 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod prefix_free_collision_probe {
+    use super::*;
+    use crate::storage::InMemoryNodeStorage;
+
+    /// Red-team attack #1: distinct (k,v) sets must NOT share a root hash. get_hash =
+    /// SHA256(keys.concat() ++ values.concat()) has no length delimiters, so values
+    /// "ab"+"c" and "a"+"bc" both concat to "abc" -> same hash input -> same root.
+    #[test]
+    fn distinct_contents_must_not_share_root() {
+        let cfg = TreeConfig::<32>::default();
+        let mut a = ProllyTree::new(InMemoryNodeStorage::<32>::default(), cfg.clone());
+        a.insert(b"k1".to_vec(), b"ab".to_vec());
+        a.insert(b"k2".to_vec(), b"c".to_vec());
+        let mut b = ProllyTree::new(InMemoryNodeStorage::<32>::default(), cfg.clone());
+        b.insert(b"k1".to_vec(), b"a".to_vec());
+        b.insert(b"k2".to_vec(), b"bc".to_vec());
+        let ra = a.get_root_hash().unwrap();
+        let rb = b.get_root_hash().unwrap();
+        // also a key-vs-value boundary collision: key "k1k2" value ... vs keys "k1","k2"
+        assert_ne!(
+            ra.as_bytes(),
+            rb.as_bytes(),
+            "PREFIX-FREE COLLISION CONFIRMED: distinct (k,v) sets share a root hash"
+        );
+    }
+}
+


### PR DESCRIPTION
## Bug

`ProllyNode::get_hash` hashes `keys.concat() ++ values.concat()` with **no length delimiters**, so distinct content can produce identical hash input:

- keys `k1,k2`, values `("ab","c")` → input `k1k2abc`
- keys `k1,k2`, values `("a","bc")` → input `k1k2abc`

→ identical root hash. For a content-addressed / merge-convergent structure this is a correctness bug (false dedup, false merge convergence).

## Repro (RED)

The added test fails on `main`:

```
distinct_contents_must_not_share_root … FAILED
"PREFIX-FREE COLLISION CONFIRMED: distinct (k,v) sets share a root hash"
```

## Fix

Length-frame every element (u32 BE lengths — **not** `usize`, so the hash is identical on 32/64-bit and wasm), delimit the key region from the value region by count, and bind `is_leaf` + `level` so a leaf can't collide with an internal node of identical bytes.

**Hash-function-agnostic**: only the `ValueDigest::new` *input* changes, not the digest algorithm — and only node *identity* changes, chunk boundaries (tree shape) are untouched, so merge-canonicality and every existing test still hold.

## Tests / verification

`mod prefix_free_collision_probe` (RED on the old concat hash, GREEN here). `cargo test` — 164/164 lib green, **0 regressions**. Fully independent of any other change. Based on `main` @ `373128e`.