### PR TITLE
fix(chunker): platform-independent hash_item + collapse single-child root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3842,6 +3842,7 @@ dependencies = [
  "parking_lot",
  "parquet",
  "predicates",
+ "proptest",
  "pyo3",
  "rand 0.9.2",
  "rocksdb",
@@ -3858,6 +3859,25 @@ dependencies = [
  "twox-hash",
  "ureq",
  "uuid",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -3962,6 +3982,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4057,6 +4083,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4324,6 +4359,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5080,6 +5127,12 @@ checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ dirs = { version = "5.0", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.2"
+proptest = "1"
 bytes = "1.10.1"
 criterion = "0.5"
 predicates = "3.0"

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,7 +20,6 @@ use crate::proof::Proof;
 use crate::storage::NodeStorage;
 use schemars::schema::RootSchema;
 use serde::{Deserialize, Serialize};
-use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 use twox_hash::XxHash64;
@@ -747,7 +746,7 @@ impl<const N: usize> NodeChunk for ProllyNode<N> {
 
     fn hash_item(item: &[u8], _base: u64, modulus: u64) -> u64 {
         let mut hasher = XxHash64::with_seed(HASH_SEED);
-        item.hash(&mut hasher);
+        hasher.write(item);
         hasher.finish() % modulus
     }
 }
@@ -1711,7 +1710,9 @@ mod tests {
 
         node.insert(vec![32], value_for_all.clone(), &mut storage, Vec::new());
 
-        assert_eq!(node.traverse(&storage), "[L0:[[17], [20], [32]]]");
+        // hash_item now hashes raw bytes (platform-independent), which shifts the
+        // content-defined chunk boundary: [17] seals its own chunk.
+        assert_eq!(node.traverse(&storage), "[L0:[[17]]][L0:[[20], [32]]]");
     }
 
     #[test]

--- a/src/streaming_chunker.rs
+++ b/src/streaming_chunker.rs
@@ -56,7 +56,7 @@ use crate::config::TreeConfig;
 use crate::node::ProllyNode;
 use crate::storage::NodeStorage;
 use std::collections::VecDeque;
-use std::hash::{Hash, Hasher};
+use std::hash::Hasher;
 use twox_hash::XxHash64;
 
 const HASH_SEED: u64 = 0;
@@ -174,7 +174,7 @@ impl Splitter for RollingHashSplitter {
 
 fn hash_item(item: &[u8], modulus: u64) -> u64 {
     let mut hasher = XxHash64::with_seed(HASH_SEED);
-    item.hash(&mut hasher);
+    hasher.write(item);
     hasher.finish() % modulus
 }
 
@@ -458,7 +458,22 @@ impl<'s, const N: usize, S: NodeStorage<N>> Chunker<'s, N, S> {
         let root = self.builder.build();
         let root_hash = root.get_hash();
         let _ = storage.insert_node(root_hash, root.clone());
-        root
+        // RT-B F1: a content-defined boundary on the FINAL item emits the chunk and pops
+        // to a fresh parent level, which can leave this top-level node with exactly one
+        // child — a degenerate, non-minimal spine that diverges from a fresh batch build
+        // / a collapsing peer. Collapse single-child internal roots to their child so the
+        // canonical form is minimal. done() is the single chokepoint for every root-
+        // producing path (build + apply_mutations + try_pure_append all reach it), so
+        // build and merge collapse identically and P-CANON is preserved.
+        let mut node = root;
+        while !node.is_leaf && node.values.len() == 1 {
+            let child_digest = crate::digest::ValueDigest::raw_hash(&node.values[0]);
+            match storage.get_node_by_hash(&child_digest) {
+                Some(child) => node = (*child).clone(),
+                None => break,
+            }
+        }
+        node
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -865,7 +865,146 @@ impl<const N: usize, S: NodeStorage<N>> ProllyTree<N, S> {
         new_node: &ProllyNode<N>,
         diffs: &mut Vec<DiffResult>,
     ) {
-        self.diff_recursive(old_node, new_node, diffs);
+        // O(differences) structural diff (Dolt/Noms): the tree is content-addressed,
+        // so equal get_hash() => byte-identical subtree => zero diffs; skip it without
+        // loading. Descend only into differing children. Emits the IDENTICAL DiffResult
+        // set as the full-leaf flatten (diff_nodes_flatten), guarded by a differential test.
+        if old_node.get_hash() == new_node.get_hash() {
+            return;
+        }
+        match (old_node.is_leaf, new_node.is_leaf) {
+            (true, true) => {
+                let o: Vec<(Vec<u8>, Vec<u8>)> = old_node
+                    .keys
+                    .iter()
+                    .cloned()
+                    .zip(old_node.values.iter().cloned())
+                    .collect();
+                let n: Vec<(Vec<u8>, Vec<u8>)> = new_node
+                    .keys
+                    .iter()
+                    .cloned()
+                    .zip(new_node.values.iter().cloned())
+                    .collect();
+                self.merge_join_pairs(&o, &n, diffs);
+            }
+            (false, false) => self.diff_internal(old_node, new_node, diffs),
+            _ => {
+                // height divergence (one side shallower): flatten the divergent region.
+                let mut op = Vec::new();
+                self.collect_pairs_recursive(old_node, &mut op);
+                let mut np = Vec::new();
+                self.collect_pairs_recursive(new_node, &mut np);
+                self.merge_join_pairs(&op, &np, diffs);
+            }
+        }
+    }
+
+    /// Both nodes internal: skip children whose stored child-hash is equal (O(1), no
+    /// load), flatten + merge-join the rest. Provably identical to the full flatten:
+    /// a common child subtree has identical (k,v) on both sides => contributes no diff.
+    fn diff_internal(
+        &self,
+        old_node: &ProllyNode<N>,
+        new_node: &ProllyNode<N>,
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        use std::collections::HashSet;
+        // The node is content-addressed: an internal node's `values` ARE its child
+        // hashes, so byte-equal `values[i]` <=> identical child subtree (same (k,v)).
+        // Skip common children by hash WITHOUT loading them (the O(diff) win), and
+        // load only the differing children (mirroring `children()`'s raw_hash lookup).
+        let new_hashes: HashSet<&Vec<u8>> = new_node.values.iter().collect();
+        let old_hashes: HashSet<&Vec<u8>> = old_node.values.iter().collect();
+        let mut old_pairs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for child_hash in &old_node.values {
+            if new_hashes.contains(child_hash) {
+                continue; // identical subtree on the new side => contributes no diff
+            }
+            if let Some(child) = self
+                .storage
+                .get_node_by_hash(&ValueDigest::raw_hash(child_hash))
+            {
+                self.collect_pairs_recursive(&child, &mut old_pairs);
+            }
+        }
+        let mut new_pairs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for child_hash in &new_node.values {
+            if old_hashes.contains(child_hash) {
+                continue;
+            }
+            if let Some(child) = self
+                .storage
+                .get_node_by_hash(&ValueDigest::raw_hash(child_hash))
+            {
+                self.collect_pairs_recursive(&child, &mut new_pairs);
+            }
+        }
+        self.merge_join_pairs(&old_pairs, &new_pairs, diffs);
+    }
+
+    /// Merge-join two sorted (key,value) streams into DiffResults.
+    fn merge_join_pairs(
+        &self,
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        let mut oi = old_pairs.iter().peekable();
+        let mut ni = new_pairs.iter().peekable();
+        while let (Some((ok, ov)), Some((nk, nv))) = (oi.peek(), ni.peek()) {
+            match ok.cmp(nk) {
+                std::cmp::Ordering::Less => {
+                    diffs.push(DiffResult::Removed(ok.clone(), ov.clone()));
+                    oi.next();
+                }
+                std::cmp::Ordering::Greater => {
+                    diffs.push(DiffResult::Added(nk.clone(), nv.clone()));
+                    ni.next();
+                }
+                std::cmp::Ordering::Equal => {
+                    if ov != nv {
+                        diffs.push(DiffResult::Modified(ok.clone(), ov.clone(), nv.clone()));
+                    }
+                    oi.next();
+                    ni.next();
+                }
+            }
+        }
+        for (ok, ov) in oi {
+            diffs.push(DiffResult::Removed(ok.clone(), ov.clone()));
+        }
+        for (nk, nv) in ni {
+            diffs.push(DiffResult::Added(nk.clone(), nv.clone()));
+        }
+    }
+
+    /// Proven full-leaf flatten diff — kept as the differential-test oracle.
+    #[cfg(test)]
+    fn diff_nodes_flatten(
+        &self,
+        old_node: &ProllyNode<N>,
+        new_node: &ProllyNode<N>,
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        let mut old_pairs = Vec::new();
+        self.collect_pairs_recursive(old_node, &mut old_pairs);
+        let mut new_pairs = Vec::new();
+        self.collect_pairs_recursive(new_node, &mut new_pairs);
+        self.merge_join_pairs(&old_pairs, &new_pairs, diffs);
+    }
+
+    /// Collect all leaf (key, value) pairs of a subtree in sorted order (full traversal).
+    fn collect_pairs_recursive(&self, node: &ProllyNode<N>, pairs: &mut Vec<(Vec<u8>, Vec<u8>)>) {
+        if node.is_leaf {
+            for (k, v) in node.keys.iter().zip(node.values.iter()) {
+                pairs.push((k.clone(), v.clone()));
+            }
+        } else {
+            for child in node.children(&self.storage) {
+                self.collect_pairs_recursive(&child, pairs);
+            }
+        }
     }
 
     /// Find a value for a specific key in a node tree
@@ -1005,6 +1144,7 @@ impl<const N: usize, S: NodeStorage<N>> ProllyTree<N, S> {
     /// * `old_node` - The node from the original tree.
     /// * `new_node` - The node from the new tree.
     /// * `diffs` - The vector to store the differences.
+    #[allow(dead_code)]
     fn diff_recursive(
         &self,
         old_node: &ProllyNode<N>,
@@ -2642,3 +2782,302 @@ mod tests {
         }
     }
 }
+
+/// O(diff) structural-diff differential tests: the structural `diff_nodes_recursive`
+/// must emit a BYTE-IDENTICAL `Vec<DiffResult>` to the proven full-leaf flatten oracle
+/// (`diff_nodes_flatten`) on every shape — and load strictly fewer nodes when a large
+/// subtree is shared. prollytree is history-independent, so shape is a function of
+/// CONTENT; divergent shapes come from divergent content with a shared region.
+#[cfg(test)]
+mod odiff_differential {
+    use super::*;
+    use crate::digest::ValueDigest;
+    use crate::storage::{InMemoryNodeStorage, NodeStorage, StorageError};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// InMemoryNodeStorage wrapper that counts `get_node_by_hash` (node loads).
+    #[derive(Clone)]
+    struct CountingStorage<const N: usize> {
+        inner: InMemoryNodeStorage<N>,
+        loads: Arc<AtomicUsize>,
+    }
+    impl<const N: usize> CountingStorage<N> {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryNodeStorage::<N>::default(),
+                loads: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+    impl<const N: usize> NodeStorage<N> for CountingStorage<N> {
+        fn get_node_by_hash(&self, hash: &ValueDigest<N>) -> Option<Arc<ProllyNode<N>>> {
+            self.loads.fetch_add(1, Ordering::SeqCst);
+            self.inner.get_node_by_hash(hash)
+        }
+        fn insert_node(
+            &mut self,
+            hash: ValueDigest<N>,
+            node: ProllyNode<N>,
+        ) -> Result<(), StorageError> {
+            self.inner.insert_node(hash, node)
+        }
+        fn delete_node(&mut self, hash: &ValueDigest<N>) -> Result<(), StorageError> {
+            self.inner.delete_node(hash)
+        }
+        fn save_config(&self, key: &str, config: &[u8]) {
+            self.inner.save_config(key, config)
+        }
+        fn get_config(&self, key: &str) -> Option<Vec<u8>> {
+            self.inner.get_config(key)
+        }
+    }
+
+    /// Build BOTH trees into ONE storage. `InMemoryNodeStorage::clone` DEEP-COPIES the
+    /// node map and `insert` persists nodes into the TREE's storage — so we must thread
+    /// one storage through both builds (clone carries old's nodes forward; new's inserts
+    /// add to it) rather than clone-then-copy-only-root (which strands all children and
+    /// makes a multi-level diff trivially empty). Returns (storage_with_both, roots).
+    fn build_two(
+        config: &TreeConfig<32>,
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> (CountingStorage<32>, ValueDigest<32>, ValueDigest<32>) {
+        let mut t_old = ProllyTree::new(CountingStorage::<32>::new(), config.clone());
+        for (k, v) in old_pairs {
+            t_old.insert(k.clone(), v.clone());
+        }
+        let old_root = t_old.get_root_hash().unwrap();
+        // Ensure the root node is present even when no insert ran (empty tree:
+        // `insert`/`persist_root` never fired).
+        t_old
+            .storage
+            .insert_node(old_root.clone(), t_old.root.clone())
+            .unwrap();
+        // clone() carries a full copy of old's nodes; new's inserts add new's nodes,
+        // never evicting old's -> the result holds BOTH complete trees.
+        let mut t_new = ProllyTree::new(t_old.storage.clone(), config.clone());
+        for (k, v) in new_pairs {
+            t_new.insert(k.clone(), v.clone());
+        }
+        let new_root = t_new.get_root_hash().unwrap();
+        t_new
+            .storage
+            .insert_node(new_root.clone(), t_new.root.clone())
+            .unwrap();
+        (t_new.storage, old_root, new_root)
+    }
+
+    /// k-th key as a fixed-width sortable 8-byte big-endian blob.
+    fn key(i: u64) -> Vec<u8> {
+        i.to_be_bytes().to_vec()
+    }
+    /// variable-length value (exercises the D14 variable-length canonicality face).
+    fn val(i: u64, tag: u8) -> Vec<u8> {
+        let mut v = vec![tag];
+        v.extend_from_slice(&i.to_le_bytes());
+        v.extend(std::iter::repeat_n(tag, (i % 19) as usize));
+        v
+    }
+
+    /// Assert structural diff == flatten oracle (exact Vec<DiffResult>), return
+    /// (structural_loads, flatten_loads) measured during the diff only.
+    fn assert_identical(
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+        label: &str,
+    ) -> (usize, usize) {
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, old_pairs, new_pairs);
+
+        // Both full trees are in `storage`; their children resolve (asserted below).
+        let old_node = storage.get_node_by_hash(&old_root).unwrap();
+        let new_node = storage.get_node_by_hash(&new_root).unwrap();
+        // HARNESS GUARD: a non-leaf root's children MUST resolve, else the diff would
+        // be trivially empty (the build_root bug). children() returns all present.
+        if !old_node.is_leaf {
+            assert_eq!(
+                old_node.children(&storage).len(),
+                old_node.values.len(),
+                "[{label}] old root children not all persisted (harness bug)"
+            );
+        }
+        if !new_node.is_leaf {
+            assert_eq!(
+                new_node.children(&storage).len(),
+                new_node.values.len(),
+                "[{label}] new root children not all persisted (harness bug)"
+            );
+        }
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+
+        storage.loads.store(0, Ordering::SeqCst);
+        let mut d_struct = Vec::new();
+        facade.diff_nodes_recursive(&old_node, &new_node, &mut d_struct);
+        let struct_loads = storage.loads.load(Ordering::SeqCst);
+
+        storage.loads.store(0, Ordering::SeqCst);
+        let mut d_flat = Vec::new();
+        facade.diff_nodes_flatten(&old_node, &new_node, &mut d_flat);
+        let flat_loads = storage.loads.load(Ordering::SeqCst);
+
+        assert_eq!(
+            d_struct, d_flat,
+            "[{label}] structural diff diverged from flatten oracle"
+        );
+        (struct_loads, flat_loads)
+    }
+
+    fn range_pairs(lo: u64, hi: u64, tag: u8) -> Vec<(Vec<u8>, Vec<u8>)> {
+        (lo..hi).map(|i| (key(i), val(i, tag))).collect()
+    }
+
+    #[test]
+    fn identical_trees_zero_diff_zero_descent() {
+        let base = range_pairs(0, 1000, 0);
+        let (s, f) = assert_identical(&base, &base, "identical");
+        // equal root hash => structural returns immediately, no descent at all.
+        assert_eq!(s, 0, "identical trees must load zero nodes structurally");
+        assert!(f >= s);
+    }
+
+    #[test]
+    fn localized_modify_skips_shared_subtrees() {
+        let old = range_pairs(0, 1000, 0);
+        let mut new = old.clone();
+        new[500].1 = val(500, 9); // one cell changed deep in the tree
+        let (s, f) = assert_identical(&old, &new, "localized_modify");
+        assert!(
+            s < f,
+            "localized change must load fewer nodes structurally ({s}) than flatten ({f})"
+        );
+        // GROUND TRUTH (not just structural==flatten): the diff must be EXACTLY the one
+        // changed cell — guards against a both-paths-lossy false pass.
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, &old, &new);
+        let on = storage.get_node_by_hash(&old_root).unwrap();
+        let nn = storage.get_node_by_hash(&new_root).unwrap();
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+        let mut d = Vec::new();
+        facade.diff_nodes_recursive(&on, &nn, &mut d);
+        assert_eq!(
+            d,
+            vec![DiffResult::Modified(key(500), val(500, 0), val(500, 9))],
+            "structural diff must report exactly the one changed cell, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn bulk_suffix_add_shares_prefix() {
+        let old = range_pairs(0, 800, 0);
+        let new = range_pairs(0, 1000, 0); // 200 appended at the high end
+        let (s, f) = assert_identical(&old, &new, "bulk_suffix_add");
+        assert!(
+            s < f,
+            "shared-prefix add should skip prefix subtrees ({s} < {f})"
+        );
+    }
+
+    #[test]
+    fn bulk_prefix_remove() {
+        let old = range_pairs(0, 1000, 0);
+        let new = range_pairs(200, 1000, 0); // low 200 removed
+        assert_identical(&old, &new, "bulk_prefix_remove");
+    }
+
+    #[test]
+    fn scattered_modifications() {
+        let old = range_pairs(0, 1000, 0);
+        let mut new = old.clone();
+        for i in (0..1000).step_by(7) {
+            new[i].1 = val(i as u64, 5); // every 7th cell changed
+        }
+        assert_identical(&old, &new, "scattered_modify");
+    }
+
+    #[test]
+    fn fully_disjoint_keyspaces() {
+        let old = range_pairs(0, 500, 0);
+        let new = range_pairs(10_000, 10_500, 0); // no overlap at all
+        assert_identical(&old, &new, "disjoint");
+    }
+
+    #[test]
+    fn interleaved_add_remove_modify() {
+        let mut old = range_pairs(0, 600, 0);
+        // remove evens, modify multiples of 3, keep odds; then add a high block.
+        let mut new: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for i in 0..600u64 {
+            if i % 2 == 0 {
+                continue; // removed
+            }
+            let tag = if i % 3 == 0 { 7 } else { 0 };
+            new.push((key(i), val(i, tag)));
+        }
+        new.extend(range_pairs(600, 720, 0));
+        old.sort();
+        new.sort();
+        assert_identical(&old, &new, "interleaved");
+    }
+
+    #[test]
+    fn ground_truth_add_remove_modify() {
+        // base 0..200; new: drop key 50, modify key 100, add key 500. Diff must be
+        // EXACTLY those three ops (sorted by key), regardless of structural pruning.
+        let old = range_pairs(0, 200, 0);
+        let mut new = old.clone();
+        new.retain(|(k, _)| k != &key(50));
+        for p in new.iter_mut() {
+            if p.0 == key(100) {
+                p.1 = val(100, 9);
+            }
+        }
+        new.push((key(500), val(500, 0)));
+        new.sort();
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, &old, &new);
+        let on = storage.get_node_by_hash(&old_root).unwrap();
+        let nn = storage.get_node_by_hash(&new_root).unwrap();
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+        let mut d = Vec::new();
+        facade.diff_nodes_recursive(&on, &nn, &mut d);
+        // merge-join emits in key order: 50 (Removed) < 100 (Modified) < 500 (Added).
+        assert_eq!(
+            d,
+            vec![
+                DiffResult::Removed(key(50), val(50, 0)),
+                DiffResult::Modified(key(100), val(100, 0), val(100, 9)),
+                DiffResult::Added(key(500), val(500, 0)),
+            ],
+            "structural diff ground truth mismatch, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn report_load_win() {
+        for n in [1_000u64, 4_000u64] {
+            let old = range_pairs(0, n, 0);
+            let mut new = old.clone();
+            new[(n / 2) as usize].1 = val(n / 2, 9); // one cell changed
+            let (s, f) = assert_identical(&old, &new, "report");
+            eprintln!(
+                "ODIFF_LOAD_WIN n={n} one-cell-change: structural_loads={s} flatten_loads={f} ratio={:.1}x",
+                f as f64 / s.max(1) as f64
+            );
+        }
+    }
+
+    #[test]
+    fn small_multilevel_and_single_leaf() {
+        // small trees (single leaf / shallow) must also match exactly.
+        assert_identical(&range_pairs(0, 3, 0), &range_pairs(0, 5, 0), "tiny");
+        assert_identical(
+            &range_pairs(0, 1, 0),
+            &range_pairs(0, 1, 1),
+            "one_key_modify",
+        );
+        assert_identical(&[], &range_pairs(0, 4, 0), "empty_to_small");
+        assert_identical(&range_pairs(0, 4, 0), &[], "small_to_empty");
+    }
+}
+

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3081,3 +3081,54 @@ mod odiff_differential {
     }
 }
 
+
+#[cfg(test)]
+mod chunker_invariants {
+    //! Red-team RT-B F1: does the production streaming path (insert) ever emit a
+    //! degenerate single-child INTERNAL node (e.g. a single-child root when the last
+    //! item triggers a boundary)? Such a form is non-minimal and would diverge from a
+    //! collapsing peer / the batch oracle. Property-search the DEFAULT config.
+    use super::*;
+    use crate::storage::InMemoryNodeStorage;
+    use proptest::prelude::*;
+
+    fn any_single_child_internal(node: &ProllyNode<32>, storage: &InMemoryNodeStorage<32>) -> bool {
+        if node.is_leaf {
+            return false;
+        }
+        if node.values.len() < 2 {
+            return true; // internal node with 0 or 1 child = degenerate spine
+        }
+        for child in node.children(storage) {
+            if any_single_child_internal(&child, storage) {
+                return true;
+            }
+        }
+        false
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(400))]
+        #[test]
+        fn streaming_build_has_no_single_child_internal_node(
+            entries in proptest::collection::vec(
+                (proptest::collection::vec(any::<u8>(), 1..6), proptest::collection::vec(any::<u8>(), 0..6)),
+                0..60,
+            )
+        ) {
+            let mut by_key: std::collections::BTreeMap<Vec<u8>, Vec<u8>> =
+                std::collections::BTreeMap::new();
+            for (k, v) in entries { by_key.insert(k, v); }
+
+            let storage = InMemoryNodeStorage::<32>::default();
+            let mut tree = ProllyTree::new(storage, TreeConfig::default());
+            for (k, v) in &by_key { tree.insert(k.clone(), v.clone()); }
+
+            prop_assert!(
+                !any_single_child_internal(&tree.root, &tree.storage),
+                "streaming build produced a single-child internal node (RT-B F1): root is_leaf={} children={}",
+                tree.root.is_leaf, tree.root.values.len()
+            );
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked on #191** (`fix/canonical-structural-diff`). This branch contains that PR's commit as its base — the first of the two commits here is #191. Please merge #191 first (or review the second commit). The dependency is **required**, not cosmetic — see below.

## Bugs

1. **Platform-dependent chunking.** `hash_item` fed the item through the slice `Hash` impl (`<[u8] as Hash>::hash`), which prefixes a platform-width `usize` length (8 bytes on 64-bit, 4 on wasm32) before the bytes. So content-defined chunk boundaries — and therefore every tree's shape and root hash — **differ between 32- and 64-bit / wasm targets**. Fixed in both `streaming_chunker` and `ProllyNode`'s `NodeChunk` by hashing the raw content bytes: `hasher.write(item)`.

2. **Single-child root.** A content-defined boundary on the final item can leave the root a single-child internal node — a non-minimal spine that diverges from a fresh batch build. `done()` now collapses single-child internal roots to their child.

## Why it depends on #191

The corrected boundaries surface the root-only diff data-loss bug **during `merge`** (merge diffs internally). With the chunker fix alone, the existing `merge_canonicality_tests` fail (4/4); with #191 present they pass. Verified: chunker-alone → 4 `merge_canonicality` failures; chunker + #191 → full suite green (272 tests).

## Tests

`mod chunker_invariants` (proptest: no single-child internal nodes over the default config). `test_delete`'s golden traverse is updated for the corrected, platform-independent boundary (`[17]` now seals its own chunk).

## Verification

`cargo test` (with #191) — full suite green. Based on `main` @ `373128e`.