### PR TITLE
[Draft] Complete hardening fork (blake3 + canonicality + wasm determinism)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -130,31 +130,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
+name = "arrayref"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "arrow"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -197,7 +197,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -280,18 +280,19 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -304,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -317,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -330,15 +331,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 
 [[package]]
 name = "arrow-select"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -350,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -367,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -388,7 +389,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -399,7 +400,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -413,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -469,7 +470,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -479,8 +480,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -489,16 +490,16 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn 2.0.117",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -518,9 +519,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmaps"
@@ -533,14 +540,28 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -554,32 +575,33 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -588,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -598,20 +620,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -652,7 +674,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -663,15 +685,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
 
 [[package]]
 name = "bzip2-sys"
@@ -697,7 +719,7 @@ dependencies = [
  "memmap2",
  "num-traits",
  "num_cpus",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr",
  "rayon",
  "safetensors",
@@ -734,7 +756,7 @@ dependencies = [
  "candle-nn",
  "fancy-regex",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "serde",
  "serde_json",
@@ -759,14 +781,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -792,9 +814,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -873,14 +895,14 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clru"
@@ -893,15 +915,15 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -933,6 +955,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +971,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1090,7 +1127,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1101,7 +1138,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1115,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1125,6 +1162,38 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1145,7 +1214,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1155,7 +1224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1177,7 +1246,7 @@ checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1219,13 +1288,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1258,9 +1327,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -1280,7 +1349,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1328,19 +1397,18 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1364,7 +1432,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "rustc_version",
 ]
 
@@ -1395,7 +1463,7 @@ checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr",
 ]
 
@@ -1500,7 +1568,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1679,22 +1747,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1770,7 +1838,7 @@ dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -1805,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7add20f40d060db8c9b1314d499bac6ed7480f33eb113ce3e1cf5d6ff85d989"
+checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
 dependencies = [
  "gix-error",
 ]
@@ -1834,18 +1902,18 @@ dependencies = [
 
 [[package]]
 name = "gix-chunk"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1096b6608fbe5d27fb4984e20f992b4e76fb8c613f6acb87d07c5831b53a6959"
+checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
 dependencies = [
  "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849c65a609f50d02f8a2774fe371650b3384a743c79c2a070ce0da49b7fb7da"
+checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1885,16 +1953,16 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92"
+checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-path",
  "libc",
@@ -1903,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.37.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b2a34b8715e3bbd514f3d1705f5d51c4b250e5bfe506b9fb60b133c85c93d9"
+checksum = "0493f25da3ce9e8f7d925e5b64dc6d0b6109c96add422a6bcada52416448147d"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1921,15 +1989,14 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39acf819aa9fee65e4838a2eec5cb2506e47ebb89e02a5ab9918196e491571ea"
+checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
 dependencies = [
  "bstr",
  "gix-error",
  "itoa",
  "jiff",
- "smallvec",
 ]
 
 [[package]]
@@ -1994,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e86d01da904d4a9265def43bd42a18c5e6dc7000a73af512946ba14579c9fbd"
+checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
 dependencies = [
  "bstr",
 ]
@@ -2064,7 +2131,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -2112,7 +2179,7 @@ version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "filetime",
  "fnv",
@@ -2189,7 +2256,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2215,7 +2282,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2262,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.21.2"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be19313dcdb7dff75a3ce2f99be00878458295bcc3b6c7f0005591597573345c"
+checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -2274,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c31d4373bda7fab9eb01822927b55185a378d6e1bf737e0a54c743ad806658"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2290,7 +2357,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -2301,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f61f6264e1f6c5a951531fe127722c7522bc02ebda80c4528286bda4642055f"
+checksum = "1de52c2570684db3eb8cebda77c1d0e3d03ddaad2d9bbb5055eba31fb9f8292a"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -2336,14 +2403,14 @@ dependencies = [
  "maybe-async",
  "nonempty",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68533db71259c8776dd4e770d2b7b98696213ecdc1f5c9e3507119e274e0c578"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2368,7 +2435,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2393,7 +2460,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -2424,11 +2491,11 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf82ae037de9c62850ce67beaa92ec8e3e17785ea307cdde7618edc215603b4f"
+checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -2502,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-transport"
@@ -2528,7 +2595,7 @@ version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2541,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d"
+checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
 dependencies = [
  "bstr",
  "gix-path",
@@ -2553,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
 dependencies = [
  "bstr",
  "fastrand",
@@ -2564,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
 dependencies = [
  "bstr",
 ]
@@ -2651,7 +2718,7 @@ dependencies = [
  "itertools 0.12.1",
  "md-5",
  "ordered-float 4.6.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rust_decimal",
  "serde",
@@ -2683,7 +2750,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr",
  "zerocopy",
 ]
@@ -2892,12 +2959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,14 +3030,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3059,41 +3118,42 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.22"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819b44bc7c87d9117eb522f14d46e918add69ff12713c475946b0a29363ed1c2"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
+ "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.22"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470252db18ecc35fd766c0891b1e3ec6cbbcd62507e85276c01bf75d8e94d4a1"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
 
 [[package]]
 name = "jiff-tzdb-platform"
@@ -3116,11 +3176,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -3144,12 +3205,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lexical-core"
@@ -3210,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -3232,14 +3287,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -3260,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3292,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -3317,9 +3369,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -3351,13 +3403,13 @@ dependencies = [
 
 [[package]]
 name = "maybe-async"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3372,15 +3424,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -3404,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3432,7 +3484,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3517,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3533,7 +3585,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -3577,7 +3629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -3599,16 +3651,16 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
 
 [[package]]
 name = "parquet"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -3623,7 +3675,7 @@ dependencies = [
  "chrono",
  "flate2",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
@@ -3651,22 +3703,22 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3677,15 +3729,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -3723,9 +3769,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -3779,22 +3825,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "proc-macro-crate"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "proc-macro2",
- "syn 2.0.117",
+ "toml_edit",
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "toml_edit",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3826,6 +3884,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
+ "blake3",
  "bytes",
  "candle-core",
  "candle-nn",
@@ -3835,6 +3894,7 @@ dependencies = [
  "criterion",
  "dirs",
  "futures",
+ "getrandom 0.3.4",
  "gix",
  "gluesql-core",
  "hex",
@@ -3842,13 +3902,13 @@ dependencies = [
  "parking_lot",
  "parquet",
  "predicates",
+ "proptest",
  "pyo3",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rocksdb",
  "schemars",
  "serde",
  "serde_json",
- "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokenizers 0.23.1",
@@ -3858,6 +3918,25 @@ dependencies = [
  "twox-hash",
  "ureq",
  "uuid",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -3882,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -3899,9 +3978,9 @@ dependencies = [
 
 [[package]]
 name = "pulp-wasm-simd-flag"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "pyo3"
@@ -3945,7 +4024,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3958,14 +4037,20 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.45"
+name = "quick-error"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3990,9 +4075,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4002,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4056,7 +4141,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4074,14 +4168,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4120,16 +4214,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4145,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4168,9 +4253,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -4236,18 +4321,19 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4258,9 +4344,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4277,7 +4363,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4286,9 +4372,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -4301,9 +4387,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -4324,6 +4410,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4372,7 +4470,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4389,9 +4487,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -4426,7 +4524,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4437,14 +4535,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4464,9 +4562,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4478,7 +4576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4490,17 +4588,6 @@ checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
  "digest",
  "sha1",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -4525,6 +4612,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4546,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -4574,9 +4667,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snap"
@@ -4586,12 +4679,12 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4645,7 +4738,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4667,9 +4760,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4684,7 +4777,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4693,7 +4786,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -4715,12 +4808,12 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4758,7 +4851,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4769,7 +4862,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4823,9 +4916,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4855,7 +4948,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -4888,7 +4981,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -4904,9 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4921,74 +5014,65 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -5009,7 +5093,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5035,9 +5119,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5057,7 +5141,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -5068,9 +5152,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uluru"
@@ -5080,6 +5164,12 @@ checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bom"
@@ -5113,15 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode_categories"
@@ -5182,11 +5266,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5242,40 +5326,32 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5283,65 +5359,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5353,14 +5395,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5417,7 +5459,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5428,7 +5470,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5475,15 +5517,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5515,28 +5548,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5552,12 +5568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,12 +5578,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5588,22 +5592,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5618,12 +5610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5634,12 +5620,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5654,12 +5634,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5672,107 +5646,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.13.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -5791,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5808,28 +5703,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5849,15 +5744,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -5889,7 +5784,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5899,16 +5794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "crc32fast",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "typed-path",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ name = "prollytree"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
 base64 = { version = "0.22.0", optional = true }
-sha2 = "0.10"
+blake3 = "1"
 tracing = { version = "0.1.37", optional = true }
 rand = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -27,9 +28,9 @@ thiserror = "2.0"
 parking_lot = "0.12"
 twox-hash = "2.0"
 serde_json = "1.0.117"
-arrow = "58.1.0"
+arrow = { version = "58.1.0", optional = true }
 schemars = "0.8"
-parquet = { version = "58.1.0", features = ["arrow"] }
+parquet = { version = "58.1.0", features = ["arrow"], optional = true }
 gix = { version = "0.81", features = ["blocking-network-client"], optional = true }
 clap = { version = "4.6", features = ["derive"], optional = true }
 lru = { version = "0.18", optional = true }
@@ -51,6 +52,7 @@ dirs = { version = "5.0", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.2"
+proptest = "1"
 bytes = "1.10.1"
 criterion = "0.5"
 predicates = "3.0"
@@ -60,6 +62,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [features]
+arrow_encoding = ["dep:arrow", "dep:parquet"]
 default = ["digest_base64", "prolly_balance_max_nodes", "git", "sql"]
 tracing = ["dep:tracing"]
 digest_base64 = ["dep:base64"]

--- a/proptest-regressions/tree.txt
+++ b/proptest-regressions/tree.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9912338e153e870b1b7a797079b4f36a43f97f5f0a48b64cbc8a0063164ddef0 # shrinks to entries = []
+cc 3cabcb1a3d1cc3947560d68d89d7960245a01524d567d0e0f21c12f25c2a0a33 # shrinks to entries = [([207, 176, 210], [8, 185]), ([211, 65, 224], [28, 131, 234]), ([246], [54, 245]), ([254, 67, 74], [33, 139, 111, 191]), ([229, 117, 95, 101, 110], [60, 193]), ([197, 119, 17, 72], [164, 123, 242, 211, 191]), ([211], []), ([245, 224, 117], [197, 123])]

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -14,7 +14,6 @@ limitations under the License.
 
 use crate::errors::ProllyTreeError;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 /// Represents a cryptographic hash of a value in a prolly tree.
 ///
@@ -58,15 +57,15 @@ impl<const N: usize> ValueDigest<N> {
         // Ensure N is not larger than 32 to prevent out-of-bounds errors
         assert!(
             N <= 32,
-            "N must be less than or equal to 32 due to SHA-256 output size"
+            "N must be less than or equal to 32 due to blake3 output size"
         );
 
-        let mut hasher = Sha256::new();
-        hasher.update(data);
-        let result = hasher.finalize();
+        // D-A (SD-5 Phase 0): blake3 is the single internal content hash. blake3 output is a
+        // fixed 32 bytes; truncate-to-N is a sound prefix (only N=32 is instantiated in practice).
+        let result = blake3::hash(data);
 
         let mut hash = [0u8; N];
-        hash.copy_from_slice(&result[..N]);
+        hash.copy_from_slice(&result.as_bytes()[..N]);
         ValueDigest(hash)
     }
 
@@ -158,19 +157,14 @@ impl<'de, const N: usize> Deserialize<'de> for ValueDigest<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sha2::{Digest, Sha256};
 
     #[test]
     fn test_value_digest_new() {
+        // D-A re-pin: ValueDigest::new is blake3 of the data (was SHA-256). This recompute pin AND the
+        // edge-wasm-uu GOLDEN_MERGE_ROOT (spikes/edge-wasm-uu/tests/determinism.rs) are the two D14 root
+        // pins the D-A swap re-captures — the latter guards the prollytree merge tier native==wasm.
         let data = b"test data";
-        let expected_hash = {
-            let mut hasher = Sha256::new();
-            hasher.update(data);
-            let result = hasher.finalize();
-            let mut hash = [0u8; 32];
-            hash.copy_from_slice(&result[..32]);
-            hash
-        };
+        let expected_hash = *blake3::hash(data).as_bytes();
 
         let value_digest = ValueDigest::<32>::new(data);
         assert_eq!(value_digest.as_bytes(), &expected_hash);

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -16,21 +16,31 @@ limitations under the License.
 
 use crate::errors::ProllyTreeError;
 use crate::node::ProllyNode;
+#[cfg(feature = "arrow_encoding")]
 use arrow::array::{Array, Float64Array};
+#[cfg(feature = "arrow_encoding")]
 use arrow::array::{ArrayRef, BooleanArray, Int32Array, StringArray};
+#[cfg(feature = "arrow_encoding")]
 use arrow::datatypes::{DataType, Field, Schema};
+#[cfg(feature = "arrow_encoding")]
 use arrow::ipc::writer::StreamWriter;
+#[cfg(feature = "arrow_encoding")]
 use arrow::record_batch::RecordBatch;
+#[cfg(feature = "arrow_encoding")]
 use parquet::arrow::arrow_writer::ArrowWriter;
 use schemars::schema::RootSchema;
 use schemars::schema::SchemaObject;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "arrow_encoding")]
 use std::sync::Arc;
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum EncodingType {
     Json,
+    Bincode,
+    #[cfg(feature = "arrow_encoding")]
     Arrow,
+    #[cfg(feature = "arrow_encoding")]
     Parquet,
 }
 
@@ -38,7 +48,10 @@ impl<const N: usize> ProllyNode<N> {
     pub fn encode_pairs(&mut self, encoding_index: usize) -> Result<(), ProllyTreeError> {
         let encoded_value = match self.encode_types[encoding_index] {
             EncodingType::Json => self.encode_json()?,
+            EncodingType::Bincode => self.encode_bincode()?,
+            #[cfg(feature = "arrow_encoding")]
             EncodingType::Arrow => self.encode_arrow()?,
+            #[cfg(feature = "arrow_encoding")]
             EncodingType::Parquet => self.encode_parquet()?,
         };
         self.encode_values[encoding_index] = encoded_value;
@@ -50,6 +63,13 @@ impl<const N: usize> ProllyNode<N> {
         Ok(serde_json::to_vec(&pairs)?)
     }
 
+    /// Canonical, byte-stable storage encoding (bincode legacy: fixed-int LE) — wasm-clean, D14.
+    fn encode_bincode(&self) -> Result<Vec<u8>, ProllyTreeError> {
+        let pairs: Vec<(&Vec<u8>, &Vec<u8>)> = self.keys.iter().zip(self.values.iter()).collect();
+        Ok(crate::serde_bincode::serialize(&pairs)?)
+    }
+
+    #[cfg(feature = "arrow_encoding")]
     fn encode_arrow(&self) -> Result<Vec<u8>, ProllyTreeError> {
         // Convert keys and values to arrays based on their schemas
         let key_batch = self.convert_to_arrow_array(&self.keys, &self.key_schema)?;
@@ -72,6 +92,7 @@ impl<const N: usize> ProllyNode<N> {
         Ok(encoded_data)
     }
 
+    #[cfg(feature = "arrow_encoding")]
     fn encode_parquet(&self) -> Result<Vec<u8>, ProllyTreeError> {
         // Convert keys and values to arrays based on their schemas
         let key_batch = self.convert_to_arrow_array(&self.keys, &self.key_schema)?;
@@ -90,6 +111,7 @@ impl<const N: usize> ProllyNode<N> {
         Ok(encoded_data)
     }
 
+    #[cfg(feature = "arrow_encoding")]
     fn combine_record_batches(
         &self,
         key_batch: RecordBatch,
@@ -122,6 +144,7 @@ impl<const N: usize> ProllyNode<N> {
         Ok(RecordBatch::try_new(schema, columns)?)
     }
 
+    #[cfg(feature = "arrow_encoding")]
     fn convert_to_arrow_array(
         &self,
         data: &[Vec<u8>],
@@ -244,7 +267,7 @@ impl<const N: usize> ProllyNode<N> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "arrow_encoding"))]
 mod tests {
     use super::*;
     use arrow::ipc::reader::StreamReader;
@@ -338,6 +361,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "arrow_encoding")]
     #[test]
     fn test_encode_arrow() {
         let mut node: ProllyNode<1024> = ProllyNode::default();
@@ -414,6 +438,7 @@ name: name1, name2
         }
     }
 
+    #[cfg(feature = "arrow_encoding")]
     #[test]
     fn test_encode_parquet() {
         let mut node: ProllyNode<1024> = ProllyNode::default();
@@ -549,5 +574,44 @@ balance: 100, -50
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod canonical_encoding_tests {
+    use super::*;
+    use crate::node::ProllyNode;
+    #[test]
+    fn root_hash_probe() {
+        let mut node = ProllyNode::<32>::init_root(b"alpha".to_vec(), b"1".to_vec());
+        for (k, v) in [
+            ("beta", "2"),
+            ("gamma", "3"),
+            ("delta", "4"),
+            ("epsilon", "5"),
+        ] {
+            node.keys.push(k.as_bytes().to_vec());
+            node.values.push(v.as_bytes().to_vec());
+        }
+        let h = node.get_hash();
+        let hex: String = h.0.iter().map(|b| format!("{:02x}", b)).collect();
+        println!("ROOT_HASH_PROBE={}", hex);
+    }
+
+    #[test]
+    fn bincode_encoding_is_byte_stable() {
+        let mut a = ProllyNode::<32>::init_root(b"key1".to_vec(), b"val1".to_vec());
+        a.keys.push(b"key2".to_vec());
+        a.values.push(b"val2".to_vec());
+        a.encode_types = vec![EncodingType::Bincode];
+        a.encode_values = vec![Vec::new()];
+        a.encode_pairs(0).unwrap();
+        let first = a.encode_values[0].clone();
+        a.encode_pairs(0).unwrap();
+        assert_eq!(
+            first, a.encode_values[0],
+            "bincode encoding must be byte-stable across runs"
+        );
+        assert!(!first.is_empty());
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,14 +44,19 @@ pub enum ProllyError {
 /// Error type for core tree operations (encoding, schema, etc.).
 #[derive(Error, Debug)]
 pub enum ProllyTreeError {
+    #[cfg(feature = "arrow_encoding")]
     #[error("Arrow error: {0}")]
     Arrow(#[from] arrow::error::ArrowError),
 
+    #[cfg(feature = "arrow_encoding")]
     #[error("Parquet error: {0}")]
     Parquet(#[from] parquet::errors::ParquetError),
 
     #[error("Serde JSON error: {0}")]
     SerdeJson(#[from] serde_json::Error),
+
+    #[error("Bincode encode error: {0}")]
+    Bincode(#[from] bincode::error::EncodeError),
 
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,7 +20,7 @@ use crate::proof::Proof;
 use crate::storage::NodeStorage;
 use schemars::schema::RootSchema;
 use serde::{Deserialize, Serialize};
-use std::hash::Hash;
+
 use std::hash::Hasher;
 use std::sync::Arc;
 use twox_hash::XxHash64;
@@ -747,7 +747,7 @@ impl<const N: usize> NodeChunk for ProllyNode<N> {
 
     fn hash_item(item: &[u8], _base: u64, modulus: u64) -> u64 {
         let mut hasher = XxHash64::with_seed(HASH_SEED);
-        item.hash(&mut hasher);
+        hasher.write(item);
         hasher.finish() % modulus
     }
 }
@@ -1122,9 +1122,27 @@ impl<const N: usize> Node<N> for ProllyNode<N> {
 // implement get hash function of the ProllyNode
 impl<const N: usize> ProllyNode<N> {
     pub fn get_hash(&self) -> ValueDigest<N> {
-        let mut keys_and_values = self.keys.concat();
-        keys_and_values.extend(&self.values.concat());
-        ValueDigest::new(&keys_and_values)
+        // PREFIX-FREE content hash. The previous `keys.concat() ++ values.concat()`
+        // had no length delimiters, so distinct (k,v) sets could collide (e.g. values
+        // "ab","c" and "a","bc" both concat to "abc") -> same root -> broken content
+        // addressing / false merge convergence. Length-frame every element (u32 BE,
+        // never usize, for native==wasm), separate the key region from the value
+        // region by count, and bind is_leaf/level so a leaf cannot collide with an
+        // internal node of identical bytes.
+        let mut buf: Vec<u8> = Vec::new();
+        buf.push(self.is_leaf as u8);
+        buf.push(self.level);
+        buf.extend_from_slice(&(self.keys.len() as u32).to_be_bytes());
+        for k in &self.keys {
+            buf.extend_from_slice(&(k.len() as u32).to_be_bytes());
+            buf.extend_from_slice(k);
+        }
+        buf.extend_from_slice(&(self.values.len() as u32).to_be_bytes());
+        for v in &self.values {
+            buf.extend_from_slice(&(v.len() as u32).to_be_bytes());
+            buf.extend_from_slice(v);
+        }
+        ValueDigest::new(&buf)
     }
 }
 
@@ -1711,7 +1729,7 @@ mod tests {
 
         node.insert(vec![32], value_for_all.clone(), &mut storage, Vec::new());
 
-        assert_eq!(node.traverse(&storage), "[L0:[[17], [20], [32]]]");
+        assert_eq!(node.traverse(&storage), "[L0:[[17]]][L0:[[20], [32]]]");
     }
 
     #[test]

--- a/src/streaming_chunker.rs
+++ b/src/streaming_chunker.rs
@@ -56,7 +56,7 @@ use crate::config::TreeConfig;
 use crate::node::ProllyNode;
 use crate::storage::NodeStorage;
 use std::collections::VecDeque;
-use std::hash::{Hash, Hasher};
+use std::hash::Hasher;
 use twox_hash::XxHash64;
 
 const HASH_SEED: u64 = 0;
@@ -174,7 +174,7 @@ impl Splitter for RollingHashSplitter {
 
 fn hash_item(item: &[u8], modulus: u64) -> u64 {
     let mut hasher = XxHash64::with_seed(HASH_SEED);
-    item.hash(&mut hasher);
+    hasher.write(item);
     hasher.finish() % modulus
 }
 
@@ -458,7 +458,22 @@ impl<'s, const N: usize, S: NodeStorage<N>> Chunker<'s, N, S> {
         let root = self.builder.build();
         let root_hash = root.get_hash();
         let _ = storage.insert_node(root_hash, root.clone());
-        root
+        // RT-B F1: a content-defined boundary on the FINAL item emits the chunk and pops
+        // to a fresh parent level, which can leave this top-level node with exactly one
+        // child — a degenerate, non-minimal spine that diverges from a fresh batch build
+        // / a collapsing peer. Collapse single-child internal roots to their child so the
+        // canonical form is minimal. done() is the single chokepoint for every root-
+        // producing path (build + apply_mutations + try_pure_append all reach it), so
+        // build and merge collapse identically and P-CANON is preserved.
+        let mut node = root;
+        while !node.is_leaf && node.values.len() == 1 {
+            let child_digest = crate::digest::ValueDigest::raw_hash(&node.values[0]);
+            match storage.get_node_by_hash(&child_digest) {
+                Some(child) => node = (*child).clone(),
+                None => break,
+            }
+        }
+        node
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -865,7 +865,146 @@ impl<const N: usize, S: NodeStorage<N>> ProllyTree<N, S> {
         new_node: &ProllyNode<N>,
         diffs: &mut Vec<DiffResult>,
     ) {
-        self.diff_recursive(old_node, new_node, diffs);
+        // O(differences) structural diff (Dolt/Noms): the tree is content-addressed,
+        // so equal get_hash() => byte-identical subtree => zero diffs; skip it without
+        // loading. Descend only into differing children. Emits the IDENTICAL DiffResult
+        // set as the full-leaf flatten (diff_nodes_flatten), guarded by a differential test.
+        if old_node.get_hash() == new_node.get_hash() {
+            return;
+        }
+        match (old_node.is_leaf, new_node.is_leaf) {
+            (true, true) => {
+                let o: Vec<(Vec<u8>, Vec<u8>)> = old_node
+                    .keys
+                    .iter()
+                    .cloned()
+                    .zip(old_node.values.iter().cloned())
+                    .collect();
+                let n: Vec<(Vec<u8>, Vec<u8>)> = new_node
+                    .keys
+                    .iter()
+                    .cloned()
+                    .zip(new_node.values.iter().cloned())
+                    .collect();
+                self.merge_join_pairs(&o, &n, diffs);
+            }
+            (false, false) => self.diff_internal(old_node, new_node, diffs),
+            _ => {
+                // height divergence (one side shallower): flatten the divergent region.
+                let mut op = Vec::new();
+                self.collect_pairs_recursive(old_node, &mut op);
+                let mut np = Vec::new();
+                self.collect_pairs_recursive(new_node, &mut np);
+                self.merge_join_pairs(&op, &np, diffs);
+            }
+        }
+    }
+
+    /// Both nodes internal: skip children whose stored child-hash is equal (O(1), no
+    /// load), flatten + merge-join the rest. Provably identical to the full flatten:
+    /// a common child subtree has identical (k,v) on both sides => contributes no diff.
+    fn diff_internal(
+        &self,
+        old_node: &ProllyNode<N>,
+        new_node: &ProllyNode<N>,
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        use std::collections::HashSet;
+        // The node is content-addressed: an internal node's `values` ARE its child
+        // hashes, so byte-equal `values[i]` <=> identical child subtree (same (k,v)).
+        // Skip common children by hash WITHOUT loading them (the O(diff) win), and
+        // load only the differing children (mirroring `children()`'s raw_hash lookup).
+        let new_hashes: HashSet<&Vec<u8>> = new_node.values.iter().collect();
+        let old_hashes: HashSet<&Vec<u8>> = old_node.values.iter().collect();
+        let mut old_pairs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for child_hash in &old_node.values {
+            if new_hashes.contains(child_hash) {
+                continue; // identical subtree on the new side => contributes no diff
+            }
+            if let Some(child) = self
+                .storage
+                .get_node_by_hash(&ValueDigest::raw_hash(child_hash))
+            {
+                self.collect_pairs_recursive(&child, &mut old_pairs);
+            }
+        }
+        let mut new_pairs: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for child_hash in &new_node.values {
+            if old_hashes.contains(child_hash) {
+                continue;
+            }
+            if let Some(child) = self
+                .storage
+                .get_node_by_hash(&ValueDigest::raw_hash(child_hash))
+            {
+                self.collect_pairs_recursive(&child, &mut new_pairs);
+            }
+        }
+        self.merge_join_pairs(&old_pairs, &new_pairs, diffs);
+    }
+
+    /// Merge-join two sorted (key,value) streams into DiffResults.
+    fn merge_join_pairs(
+        &self,
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        let mut oi = old_pairs.iter().peekable();
+        let mut ni = new_pairs.iter().peekable();
+        while let (Some((ok, ov)), Some((nk, nv))) = (oi.peek(), ni.peek()) {
+            match ok.cmp(nk) {
+                std::cmp::Ordering::Less => {
+                    diffs.push(DiffResult::Removed(ok.clone(), ov.clone()));
+                    oi.next();
+                }
+                std::cmp::Ordering::Greater => {
+                    diffs.push(DiffResult::Added(nk.clone(), nv.clone()));
+                    ni.next();
+                }
+                std::cmp::Ordering::Equal => {
+                    if ov != nv {
+                        diffs.push(DiffResult::Modified(ok.clone(), ov.clone(), nv.clone()));
+                    }
+                    oi.next();
+                    ni.next();
+                }
+            }
+        }
+        for (ok, ov) in oi {
+            diffs.push(DiffResult::Removed(ok.clone(), ov.clone()));
+        }
+        for (nk, nv) in ni {
+            diffs.push(DiffResult::Added(nk.clone(), nv.clone()));
+        }
+    }
+
+    /// Proven full-leaf flatten diff — kept as the differential-test oracle.
+    #[cfg(test)]
+    fn diff_nodes_flatten(
+        &self,
+        old_node: &ProllyNode<N>,
+        new_node: &ProllyNode<N>,
+        diffs: &mut Vec<DiffResult>,
+    ) {
+        let mut old_pairs = Vec::new();
+        self.collect_pairs_recursive(old_node, &mut old_pairs);
+        let mut new_pairs = Vec::new();
+        self.collect_pairs_recursive(new_node, &mut new_pairs);
+        self.merge_join_pairs(&old_pairs, &new_pairs, diffs);
+    }
+
+    /// Collect all leaf (key, value) pairs of a subtree in sorted order (full traversal).
+    fn collect_pairs_recursive(&self, node: &ProllyNode<N>, pairs: &mut Vec<(Vec<u8>, Vec<u8>)>) {
+        if node.is_leaf {
+            for (k, v) in node.keys.iter().zip(node.values.iter()) {
+                pairs.push((k.clone(), v.clone()));
+            }
+        } else {
+            for child in node.children(&self.storage) {
+                self.collect_pairs_recursive(&child, pairs);
+            }
+        }
     }
 
     /// Find a value for a specific key in a node tree
@@ -1005,6 +1144,7 @@ impl<const N: usize, S: NodeStorage<N>> ProllyTree<N, S> {
     /// * `old_node` - The node from the original tree.
     /// * `new_node` - The node from the new tree.
     /// * `diffs` - The vector to store the differences.
+    #[allow(dead_code)]
     fn diff_recursive(
         &self,
         old_node: &ProllyNode<N>,
@@ -2638,6 +2778,516 @@ mod tests {
                 merged.get_root_hash().unwrap(),
                 expected_root,
                 "TakeDestinationResolver merge output is non-canonical"
+            );
+        }
+    }
+}
+
+/// O(diff) structural-diff differential tests: the structural `diff_nodes_recursive`
+/// must emit a BYTE-IDENTICAL `Vec<DiffResult>` to the proven full-leaf flatten oracle
+/// (`diff_nodes_flatten`) on every shape — and load strictly fewer nodes when a large
+/// subtree is shared. prollytree is history-independent, so shape is a function of
+/// CONTENT; divergent shapes come from divergent content with a shared region.
+#[cfg(test)]
+mod odiff_differential {
+    use super::*;
+    use crate::digest::ValueDigest;
+    use crate::storage::{InMemoryNodeStorage, NodeStorage, StorageError};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// InMemoryNodeStorage wrapper that counts `get_node_by_hash` (node loads).
+    #[derive(Clone)]
+    struct CountingStorage<const N: usize> {
+        inner: InMemoryNodeStorage<N>,
+        loads: Arc<AtomicUsize>,
+    }
+    impl<const N: usize> CountingStorage<N> {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryNodeStorage::<N>::default(),
+                loads: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+    impl<const N: usize> NodeStorage<N> for CountingStorage<N> {
+        fn get_node_by_hash(&self, hash: &ValueDigest<N>) -> Option<Arc<ProllyNode<N>>> {
+            self.loads.fetch_add(1, Ordering::SeqCst);
+            self.inner.get_node_by_hash(hash)
+        }
+        fn insert_node(
+            &mut self,
+            hash: ValueDigest<N>,
+            node: ProllyNode<N>,
+        ) -> Result<(), StorageError> {
+            self.inner.insert_node(hash, node)
+        }
+        fn delete_node(&mut self, hash: &ValueDigest<N>) -> Result<(), StorageError> {
+            self.inner.delete_node(hash)
+        }
+        fn save_config(&self, key: &str, config: &[u8]) {
+            self.inner.save_config(key, config)
+        }
+        fn get_config(&self, key: &str) -> Option<Vec<u8>> {
+            self.inner.get_config(key)
+        }
+    }
+
+    /// Build BOTH trees into ONE storage. `InMemoryNodeStorage::clone` DEEP-COPIES the
+    /// node map and `insert` persists nodes into the TREE's storage — so we must thread
+    /// one storage through both builds (clone carries old's nodes forward; new's inserts
+    /// add to it) rather than clone-then-copy-only-root (which strands all children and
+    /// makes a multi-level diff trivially empty). Returns (storage_with_both, roots).
+    fn build_two(
+        config: &TreeConfig<32>,
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> (CountingStorage<32>, ValueDigest<32>, ValueDigest<32>) {
+        let mut t_old = ProllyTree::new(CountingStorage::<32>::new(), config.clone());
+        for (k, v) in old_pairs {
+            t_old.insert(k.clone(), v.clone());
+        }
+        let old_root = t_old.get_root_hash().unwrap();
+        // Ensure the root node is present even when no insert ran (empty tree:
+        // `insert`/`persist_root` never fired).
+        t_old
+            .storage
+            .insert_node(old_root.clone(), t_old.root.clone())
+            .unwrap();
+        // clone() carries a full copy of old's nodes; new's inserts add new's nodes,
+        // never evicting old's -> the result holds BOTH complete trees.
+        let mut t_new = ProllyTree::new(t_old.storage.clone(), config.clone());
+        for (k, v) in new_pairs {
+            t_new.insert(k.clone(), v.clone());
+        }
+        let new_root = t_new.get_root_hash().unwrap();
+        t_new
+            .storage
+            .insert_node(new_root.clone(), t_new.root.clone())
+            .unwrap();
+        (t_new.storage, old_root, new_root)
+    }
+
+    /// k-th key as a fixed-width sortable 8-byte big-endian blob.
+    fn key(i: u64) -> Vec<u8> {
+        i.to_be_bytes().to_vec()
+    }
+    /// variable-length value (exercises the D14 variable-length canonicality face).
+    fn val(i: u64, tag: u8) -> Vec<u8> {
+        let mut v = vec![tag];
+        v.extend_from_slice(&i.to_le_bytes());
+        v.extend(std::iter::repeat_n(tag, (i % 19) as usize));
+        v
+    }
+
+    /// Assert structural diff == flatten oracle (exact Vec<DiffResult>), return
+    /// (structural_loads, flatten_loads) measured during the diff only.
+    fn assert_identical(
+        old_pairs: &[(Vec<u8>, Vec<u8>)],
+        new_pairs: &[(Vec<u8>, Vec<u8>)],
+        label: &str,
+    ) -> (usize, usize) {
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, old_pairs, new_pairs);
+
+        // Both full trees are in `storage`; their children resolve (asserted below).
+        let old_node = storage.get_node_by_hash(&old_root).unwrap();
+        let new_node = storage.get_node_by_hash(&new_root).unwrap();
+        // HARNESS GUARD: a non-leaf root's children MUST resolve, else the diff would
+        // be trivially empty (the build_root bug). children() returns all present.
+        if !old_node.is_leaf {
+            assert_eq!(
+                old_node.children(&storage).len(),
+                old_node.values.len(),
+                "[{label}] old root children not all persisted (harness bug)"
+            );
+        }
+        if !new_node.is_leaf {
+            assert_eq!(
+                new_node.children(&storage).len(),
+                new_node.values.len(),
+                "[{label}] new root children not all persisted (harness bug)"
+            );
+        }
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+
+        storage.loads.store(0, Ordering::SeqCst);
+        let mut d_struct = Vec::new();
+        facade.diff_nodes_recursive(&old_node, &new_node, &mut d_struct);
+        let struct_loads = storage.loads.load(Ordering::SeqCst);
+
+        storage.loads.store(0, Ordering::SeqCst);
+        let mut d_flat = Vec::new();
+        facade.diff_nodes_flatten(&old_node, &new_node, &mut d_flat);
+        let flat_loads = storage.loads.load(Ordering::SeqCst);
+
+        assert_eq!(
+            d_struct, d_flat,
+            "[{label}] structural diff diverged from flatten oracle"
+        );
+        (struct_loads, flat_loads)
+    }
+
+    fn range_pairs(lo: u64, hi: u64, tag: u8) -> Vec<(Vec<u8>, Vec<u8>)> {
+        (lo..hi).map(|i| (key(i), val(i, tag))).collect()
+    }
+
+    #[test]
+    fn identical_trees_zero_diff_zero_descent() {
+        let base = range_pairs(0, 1000, 0);
+        let (s, f) = assert_identical(&base, &base, "identical");
+        // equal root hash => structural returns immediately, no descent at all.
+        assert_eq!(s, 0, "identical trees must load zero nodes structurally");
+        assert!(f >= s);
+    }
+
+    #[test]
+    fn localized_modify_skips_shared_subtrees() {
+        let old = range_pairs(0, 1000, 0);
+        let mut new = old.clone();
+        new[500].1 = val(500, 9); // one cell changed deep in the tree
+        let (s, f) = assert_identical(&old, &new, "localized_modify");
+        assert!(
+            s < f,
+            "localized change must load fewer nodes structurally ({s}) than flatten ({f})"
+        );
+        // GROUND TRUTH (not just structural==flatten): the diff must be EXACTLY the one
+        // changed cell — guards against a both-paths-lossy false pass.
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, &old, &new);
+        let on = storage.get_node_by_hash(&old_root).unwrap();
+        let nn = storage.get_node_by_hash(&new_root).unwrap();
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+        let mut d = Vec::new();
+        facade.diff_nodes_recursive(&on, &nn, &mut d);
+        assert_eq!(
+            d,
+            vec![DiffResult::Modified(key(500), val(500, 0), val(500, 9))],
+            "structural diff must report exactly the one changed cell, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn bulk_suffix_add_shares_prefix() {
+        let old = range_pairs(0, 800, 0);
+        let new = range_pairs(0, 1000, 0); // 200 appended at the high end
+        let (s, f) = assert_identical(&old, &new, "bulk_suffix_add");
+        assert!(
+            s < f,
+            "shared-prefix add should skip prefix subtrees ({s} < {f})"
+        );
+    }
+
+    #[test]
+    fn bulk_prefix_remove() {
+        let old = range_pairs(0, 1000, 0);
+        let new = range_pairs(200, 1000, 0); // low 200 removed
+        assert_identical(&old, &new, "bulk_prefix_remove");
+    }
+
+    #[test]
+    fn scattered_modifications() {
+        let old = range_pairs(0, 1000, 0);
+        let mut new = old.clone();
+        for i in (0..1000).step_by(7) {
+            new[i].1 = val(i as u64, 5); // every 7th cell changed
+        }
+        assert_identical(&old, &new, "scattered_modify");
+    }
+
+    #[test]
+    fn fully_disjoint_keyspaces() {
+        let old = range_pairs(0, 500, 0);
+        let new = range_pairs(10_000, 10_500, 0); // no overlap at all
+        assert_identical(&old, &new, "disjoint");
+    }
+
+    #[test]
+    fn interleaved_add_remove_modify() {
+        let mut old = range_pairs(0, 600, 0);
+        // remove evens, modify multiples of 3, keep odds; then add a high block.
+        let mut new: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        for i in 0..600u64 {
+            if i % 2 == 0 {
+                continue; // removed
+            }
+            let tag = if i % 3 == 0 { 7 } else { 0 };
+            new.push((key(i), val(i, tag)));
+        }
+        new.extend(range_pairs(600, 720, 0));
+        old.sort();
+        new.sort();
+        assert_identical(&old, &new, "interleaved");
+    }
+
+    #[test]
+    fn ground_truth_add_remove_modify() {
+        // base 0..200; new: drop key 50, modify key 100, add key 500. Diff must be
+        // EXACTLY those three ops (sorted by key), regardless of structural pruning.
+        let old = range_pairs(0, 200, 0);
+        let mut new = old.clone();
+        new.retain(|(k, _)| k != &key(50));
+        for p in new.iter_mut() {
+            if p.0 == key(100) {
+                p.1 = val(100, 9);
+            }
+        }
+        new.push((key(500), val(500, 0)));
+        new.sort();
+        let config = TreeConfig::<32>::default();
+        let (storage, old_root, new_root) = build_two(&config, &old, &new);
+        let on = storage.get_node_by_hash(&old_root).unwrap();
+        let nn = storage.get_node_by_hash(&new_root).unwrap();
+        let facade = ProllyTree::new(storage.clone(), config.clone());
+        let mut d = Vec::new();
+        facade.diff_nodes_recursive(&on, &nn, &mut d);
+        // merge-join emits in key order: 50 (Removed) < 100 (Modified) < 500 (Added).
+        assert_eq!(
+            d,
+            vec![
+                DiffResult::Removed(key(50), val(50, 0)),
+                DiffResult::Modified(key(100), val(100, 0), val(100, 9)),
+                DiffResult::Added(key(500), val(500, 0)),
+            ],
+            "structural diff ground truth mismatch, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn report_load_win() {
+        for n in [1_000u64, 4_000u64] {
+            let old = range_pairs(0, n, 0);
+            let mut new = old.clone();
+            new[(n / 2) as usize].1 = val(n / 2, 9); // one cell changed
+            let (s, f) = assert_identical(&old, &new, "report");
+            eprintln!(
+                "ODIFF_LOAD_WIN n={n} one-cell-change: structural_loads={s} flatten_loads={f} ratio={:.1}x",
+                f as f64 / s.max(1) as f64
+            );
+        }
+    }
+
+    #[test]
+    fn small_multilevel_and_single_leaf() {
+        // small trees (single leaf / shallow) must also match exactly.
+        assert_identical(&range_pairs(0, 3, 0), &range_pairs(0, 5, 0), "tiny");
+        assert_identical(
+            &range_pairs(0, 1, 0),
+            &range_pairs(0, 1, 1),
+            "one_key_modify",
+        );
+        assert_identical(&[], &range_pairs(0, 4, 0), "empty_to_small");
+        assert_identical(&range_pairs(0, 4, 0), &[], "small_to_empty");
+    }
+}
+
+#[cfg(test)]
+mod prefix_free_collision_probe {
+    use super::*;
+    use crate::storage::InMemoryNodeStorage;
+
+    /// Red-team attack #1: distinct (k,v) sets must NOT share a root hash. get_hash =
+    /// SHA256(keys.concat() ++ values.concat()) has no length delimiters, so values
+    /// "ab"+"c" and "a"+"bc" both concat to "abc" -> same hash input -> same root.
+    #[test]
+    fn distinct_contents_must_not_share_root() {
+        let cfg = TreeConfig::<32>::default();
+        let mut a = ProllyTree::new(InMemoryNodeStorage::<32>::default(), cfg.clone());
+        a.insert(b"k1".to_vec(), b"ab".to_vec());
+        a.insert(b"k2".to_vec(), b"c".to_vec());
+        let mut b = ProllyTree::new(InMemoryNodeStorage::<32>::default(), cfg.clone());
+        b.insert(b"k1".to_vec(), b"a".to_vec());
+        b.insert(b"k2".to_vec(), b"bc".to_vec());
+        let ra = a.get_root_hash().unwrap();
+        let rb = b.get_root_hash().unwrap();
+        // also a key-vs-value boundary collision: key "k1k2" value ... vs keys "k1","k2"
+        assert_ne!(
+            ra.as_bytes(),
+            rb.as_bytes(),
+            "PREFIX-FREE COLLISION CONFIRMED: distinct (k,v) sets share a root hash"
+        );
+    }
+}
+
+#[cfg(test)]
+mod pcanon_property {
+    //! Attack #2: property-test P-CANON (merge head == fresh canonical build) AND the
+    //! merged (k,v) multiset (root-only checks once hid a 22/32 data loss), over RANDOM
+    //! conflict-free merges — variable-length byte keys/values incl. 0x00/0xFF.
+    use super::*;
+    use crate::storage::InMemoryNodeStorage;
+    use proptest::prelude::*;
+
+    fn build_pairs(
+        storage: &mut InMemoryNodeStorage<32>,
+        pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> ValueDigest<32> {
+        let mut tree = ProllyTree::new(storage.clone(), TreeConfig::default());
+        for (k, v) in pairs {
+            tree.insert(k.clone(), v.clone());
+        }
+        let root = tree.get_root_hash().unwrap();
+        // persist the root explicitly so the empty-tree case (no insert -> no
+        // persist_root) is still loadable by merge().
+        tree.storage
+            .insert_node(root.clone(), tree.root.clone())
+            .unwrap();
+        *storage = tree.storage; // promote all nodes into the shared store
+        root
+    }
+
+    fn get_value(tree: &ProllyTree<32, InMemoryNodeStorage<32>>, key: &[u8]) -> Option<Vec<u8>> {
+        tree.find(key).and_then(|n| {
+            n.keys
+                .iter()
+                .position(|k| k.as_slice() == key)
+                .map(|i| n.values[i].clone())
+        })
+    }
+
+    // one entry: a unique key, a role (0..5), and a value.
+    fn entry_strategy() -> impl Strategy<Value = (Vec<u8>, u8, Vec<u8>)> {
+        (
+            proptest::collection::vec(any::<u8>(), 1..6), // key: 1..6 arbitrary bytes
+            0u8..5,                                       // role
+            proptest::collection::vec(any::<u8>(), 0..6), // value (may be empty)
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(200))]
+        #[test]
+        fn p_canon_random_conflict_free_merge(entries in proptest::collection::vec(entry_strategy(), 0..40)) {
+            // Dedupe by key so each key has exactly one role (keeps the merge conflict-free).
+            let mut by_key: std::collections::BTreeMap<Vec<u8>, (u8, Vec<u8>)> =
+                std::collections::BTreeMap::new();
+            for (k, role, v) in entries {
+                by_key.entry(k).or_insert((role, v));
+            }
+
+            // roles: 0 shared-keep, 1 ours-del, 2 theirs-del, 3 ours-add, 4 theirs-add.
+            let mut base = Vec::new();   // roles 0,1,2
+            let mut ours = Vec::new();   // roles 0,2,3
+            let mut theirs = Vec::new(); // roles 0,1,4
+            let mut expected = Vec::new(); // roles 0,3,4
+            for (k, (role, v)) in &by_key {
+                let kv = (k.clone(), v.clone());
+                match role {
+                    0 => { base.push(kv.clone()); ours.push(kv.clone()); theirs.push(kv.clone()); expected.push(kv); }
+                    1 => { base.push(kv.clone()); theirs.push(kv); }
+                    2 => { base.push(kv.clone()); ours.push(kv); }
+                    3 => { ours.push(kv.clone()); expected.push(kv); }
+                    _ => { theirs.push(kv.clone()); expected.push(kv); }
+                }
+            }
+
+            let mut storage = InMemoryNodeStorage::<32>::default();
+            let base_root = build_pairs(&mut storage, &base);
+            let ours_root = build_pairs(&mut storage, &ours);
+            let theirs_root = build_pairs(&mut storage, &theirs);
+            let expected_root = build_pairs(&mut storage, &expected);
+
+            let tool = ProllyTree::new(storage, TreeConfig::default());
+            let results = tool.merge(&ours_root, &theirs_root, &base_root);
+            let merged = tool
+                .apply_merge_results(&theirs_root, &results)
+                .expect("conflict-free merge must not error");
+
+            // (1) P-CANON: merge head == fresh canonical build of the final set.
+            prop_assert_eq!(
+                merged.get_root_hash().unwrap(),
+                expected_root,
+                "P-CANON: merged root != fresh build of final set"
+            );
+
+            // (2) multiset guard: exact key set + per-key value (independent of the root).
+            let mut got_keys = merged.collect_keys();
+            got_keys.sort();
+            let mut want_keys: Vec<Vec<u8>> = expected.iter().map(|(k, _)| k.clone()).collect();
+            want_keys.sort();
+            prop_assert_eq!(&got_keys, &want_keys, "merged key-set != expected (data loss/gain)");
+            for (k, v) in &expected {
+                let got = get_value(&merged, k);
+                prop_assert_eq!(got.as_ref(), Some(v), "merged value mismatch for key");
+            }
+        }
+
+        #[test]
+        fn build_is_history_independent(
+            entries in proptest::collection::vec(
+                (proptest::collection::vec(any::<u8>(), 1..6), proptest::collection::vec(any::<u8>(), 0..6)),
+                0..40,
+            )
+        ) {
+            // Dedupe to a set (last value wins per key).
+            let mut by_key: std::collections::BTreeMap<Vec<u8>, Vec<u8>> =
+                std::collections::BTreeMap::new();
+            for (k, v) in entries {
+                by_key.insert(k, v);
+            }
+            let fwd: Vec<(Vec<u8>, Vec<u8>)> = by_key.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            let mut rev = fwd.clone();
+            rev.reverse();
+            // a third order: sorted by VALUE then key (a different permutation than key order).
+            let mut byval = fwd.clone();
+            byval.sort_by(|a, b| a.1.cmp(&b.1).then(a.0.cmp(&b.0)));
+
+            // Build each ordering in its OWN storage so insertion order is the only variable.
+            let r_fwd = build_pairs(&mut InMemoryNodeStorage::<32>::default(), &fwd);
+            let r_rev = build_pairs(&mut InMemoryNodeStorage::<32>::default(), &rev);
+            let r_val = build_pairs(&mut InMemoryNodeStorage::<32>::default(), &byval);
+            prop_assert_eq!(r_fwd.clone(), r_rev, "root depends on insert order (fwd vs rev)");
+            prop_assert_eq!(r_fwd, r_val, "root depends on insert order (fwd vs by-value)");
+        }
+    }
+}
+
+#[cfg(test)]
+mod chunker_invariants {
+    //! Red-team RT-B F1: does the production streaming path (insert) ever emit a
+    //! degenerate single-child INTERNAL node (e.g. a single-child root when the last
+    //! item triggers a boundary)? Such a form is non-minimal and would diverge from a
+    //! collapsing peer / the batch oracle. Property-search the DEFAULT config.
+    use super::*;
+    use crate::storage::InMemoryNodeStorage;
+    use proptest::prelude::*;
+
+    fn any_single_child_internal(node: &ProllyNode<32>, storage: &InMemoryNodeStorage<32>) -> bool {
+        if node.is_leaf {
+            return false;
+        }
+        if node.values.len() < 2 {
+            return true; // internal node with 0 or 1 child = degenerate spine
+        }
+        for child in node.children(storage) {
+            if any_single_child_internal(&child, storage) {
+                return true;
+            }
+        }
+        false
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(400))]
+        #[test]
+        fn streaming_build_has_no_single_child_internal_node(
+            entries in proptest::collection::vec(
+                (proptest::collection::vec(any::<u8>(), 1..6), proptest::collection::vec(any::<u8>(), 0..6)),
+                0..60,
+            )
+        ) {
+            let mut by_key: std::collections::BTreeMap<Vec<u8>, Vec<u8>> =
+                std::collections::BTreeMap::new();
+            for (k, v) in entries { by_key.insert(k, v); }
+
+            let storage = InMemoryNodeStorage::<32>::default();
+            let mut tree = ProllyTree::new(storage, TreeConfig::default());
+            for (k, v) in &by_key { tree.insert(k.clone(), v.clone()); }
+
+            prop_assert!(
+                !any_single_child_internal(&tree.root, &tree.storage),
+                "streaming build produced a single-child internal node (RT-B F1): root is_leaf={} children={}",
+                tree.root.is_leaf, tree.root.values.len()
             );
         }
     }


### PR DESCRIPTION
**Draft / for reference — not a single mergeable unit.** This is the complete set of changes I run on top of `main` @ `373128e`, opened so you can see the whole picture and cherry-pick. The clean, individually-reviewable fixes are already split out:

- #191 — canonical structural diff (data-loss fix)
- #192 — prefix-free node hashing (collision fix)
- #193 — chunker canonical roots (platform-independent `hash_item` + single-child collapse)

## What else is in here (beyond #191–193)

These are **design customizations**, not proposed as standalone fixes:

| Area | Change | Note |
|------|--------|------|
| `digest.rs` | `sha2` → **blake3** | perf/design; **BREAKING** for content addressing |
| `encoding.rs` | D14 byte-stable canonical encoding | `native == wasm` determinism |
| `Cargo.toml` | `arrow`/`parquet` → optional behind `arrow_encoding`; `getrandom`/`wasm_js`; `blake3`; `proptest` dev-dep | smaller default build + wasm target |
| `errors.rs` | `Bincode` encode error variant | supports the encoding work |
| tests | full canonicality suite: `odiff_differential`, `prefix_free_collision_probe`, `pcanon_property`, `chunker_invariants` + regression seeds | property-level coverage |

## Status

`cargo test` (default features) — **273 passed, 0 failed**. Throwaway `examples/zzprobe*.rs` spike probes are omitted.

The `sha2 → blake3` swap is the one piece I'd expect you to weigh carefully (it changes every content hash). Everything correctness-relevant is available without it via #191–193 — those are green on plain `sha2`.