### PR TITLE
fix(node): avoid rolling-hash overflow panic

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -696,11 +696,12 @@ impl<const N: usize> NodeChunk for ProllyNode<N> {
         base: u64,
         modulus: u64,
     ) -> u64 {
-        let mut hash = 0;
+        let mut hash: u64 = 0;
         for (key, value) in keys.iter().zip(values) {
-            hash = (hash * base
-                + Self::hash_item(key, base, modulus)
-                + Self::hash_item(value, base, modulus))
+            hash = hash
+                .wrapping_mul(base)
+                .wrapping_add(Self::hash_item(key, base, modulus))
+                .wrapping_add(Self::hash_item(value, base, modulus))
                 % modulus;
         }
         hash
@@ -723,23 +724,28 @@ impl<const N: usize> NodeChunk for ProllyNode<N> {
 
         let base_exp_window_size = Self::mod_exp(base, window_size, modulus);
 
-        let hash = (old_hash * base + new_key_hash + new_value_hash) % modulus;
-        let hash = (hash + modulus - (old_key_hash * base_exp_window_size) % modulus) % modulus;
+        let hash = old_hash
+            .wrapping_mul(base)
+            .wrapping_add(new_key_hash)
+            .wrapping_add(new_value_hash)
+            % modulus;
+        let hash = (hash + modulus - (old_key_hash.wrapping_mul(base_exp_window_size)) % modulus)
+            % modulus;
 
-        (hash + modulus - (old_value_hash * base_exp_window_size) % modulus) % modulus
+        (hash + modulus - (old_value_hash.wrapping_mul(base_exp_window_size)) % modulus) % modulus
     }
 
     fn mod_exp(base: u64, exp: u64, modulus: u64) -> u64 {
-        let mut result = 1;
+        let mut result: u64 = 1;
         let mut base = base % modulus;
         let mut exp = exp;
 
         while exp > 0 {
             if exp % 2 == 1 {
-                result = (result * base) % modulus;
+                result = (result.wrapping_mul(base)) % modulus;
             }
             exp >>= 1;
-            base = (base * base) % modulus;
+            base = (base.wrapping_mul(base)) % modulus;
         }
 
         result

--- a/src/streaming_chunker.rs
+++ b/src/streaming_chunker.rs
@@ -138,13 +138,23 @@ impl Splitter for RollingHashSplitter {
         if self.window.len() < self.min_chunk_size {
             // Building the initial window. This mirrors
             // `initialize_rolling_hash`: hash = hash * base + kh + vh.
-            self.hash = (self.hash.wrapping_mul(self.base) + kh + vh) % self.modulus;
+            self.hash = self
+                .hash
+                .wrapping_mul(self.base)
+                .wrapping_add(kh)
+                .wrapping_add(vh)
+                % self.modulus;
             self.window.push_back((kh, vh));
         } else {
             // Slide: drop the front of the window, add the new item.
             // Matches `update_rolling_hash`.
             let (old_kh, old_vh) = self.window.pop_front().unwrap();
-            let mut h = (self.hash.wrapping_mul(self.base) + kh + vh) % self.modulus;
+            let mut h = self
+                .hash
+                .wrapping_mul(self.base)
+                .wrapping_add(kh)
+                .wrapping_add(vh)
+                % self.modulus;
             h = (h + self.modulus - (old_kh.wrapping_mul(self.base_exp_min)) % self.modulus)
                 % self.modulus;
             h = (h + self.modulus - (old_vh.wrapping_mul(self.base_exp_min)) % self.modulus)

--- a/tests/rolling_hash_overflow.rs
+++ b/tests/rolling_hash_overflow.rs
@@ -1,0 +1,73 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use prollytree::config::TreeConfig;
+use prollytree::node::{Node, ProllyNode};
+use prollytree::storage::InMemoryNodeStorage;
+use prollytree::tree::{ProllyTree, Tree};
+
+fn large_modulus_config() -> TreeConfig<32> {
+    TreeConfig::<32> {
+        base: 4_000_000_007,
+        modulus: 5_000_000_000,
+        min_chunk_size: 2,
+        max_chunk_size: 8,
+        pattern: 0b11,
+        ..TreeConfig::default()
+    }
+}
+
+#[test]
+fn build_canonical_large_modulus_does_not_overflow_and_preserves_keys() {
+    let config = large_modulus_config();
+    let pairs: Vec<_> = (0..64u64)
+        .map(|i| (i.to_be_bytes().to_vec(), format!("value-{i}").into_bytes()))
+        .collect();
+    let mut storage = InMemoryNodeStorage::<32>::default();
+
+    let root = ProllyNode::<32>::build_canonical_from_pairs(pairs.clone(), &config, &mut storage);
+
+    for (key, value) in pairs {
+        let leaf = root
+            .find(&key, &storage)
+            .expect("key should be retrievable");
+        let index = leaf
+            .keys
+            .iter()
+            .position(|stored_key| stored_key == &key)
+            .expect("leaf should contain key");
+        assert_eq!(leaf.values[index], value);
+    }
+}
+
+#[test]
+fn prolly_tree_large_modulus_does_not_overflow_and_preserves_keys() {
+    let config = large_modulus_config();
+    let mut tree = ProllyTree::new(InMemoryNodeStorage::<32>::default(), config);
+
+    for i in 0..64u64 {
+        tree.insert(i.to_be_bytes().to_vec(), format!("value-{i}").into_bytes());
+    }
+
+    for i in 0..64u64 {
+        let key = i.to_be_bytes().to_vec();
+        let leaf = tree.find(&key).expect("key should be retrievable");
+        let index = leaf
+            .keys
+            .iter()
+            .position(|stored_key| stored_key == &key)
+            .expect("leaf should contain key");
+        assert_eq!(leaf.values[index], format!("value-{i}").into_bytes());
+    }
+}


### PR DESCRIPTION
# Rolling Hash Handles Large Modulus Configs

## Bug

The rolling-hash chunking code used unchecked `u64` arithmetic before reducing modulo `TreeConfig::modulus`. Large valid `base` and `modulus` values could overflow in debug builds and panic during canonical tree construction or normal insertion.

## Impact

Tree configuration is part of the public surface. A caller could choose a large modulus to reduce hash-pattern collisions and then hit runtime panics while inserting otherwise valid keys. Since chunking drives tree shape, the failure blocked both regular `ProllyTree` operations and canonical rebuild paths.

## Root Cause

`initialize_rolling_hash`, `update_rolling_hash`, and modular exponentiation multiplied and added `u64` values directly. The code reduced the result modulo `modulus`, but that reduction happened after the overflow point.

## Regression Proof

The regression suite defines a large-modulus config and exercises both construction paths:

- `build_canonical_large_modulus_does_not_overflow_and_preserves_keys`
- `prolly_tree_large_modulus_does_not_overflow_and_preserves_keys`

On `main`, the debug build panics with arithmetic overflow before the assertions can verify key retrieval.

## Fix

The branch switches rolling-hash multiplication and addition to explicit wrapping arithmetic before modulo reduction in both the node chunker and streaming chunker. That makes overflow behavior deliberate, deterministic, and consistent across build profiles.

The tests assert not only that the operations stop panicking, but that every inserted key remains retrievable with its original value.

## Verification

Run from a temporary target directory:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-target cargo test --test rolling_hash_overflow
CARGO_TARGET_DIR=/tmp/prollytree-target cargo test --features "git sql"
```
