### PR TITLE
fix: reject mismatched blob inserts across backends

### DIFF
--- a/src/rocksdb/storage.rs
+++ b/src/rocksdb/storage.rs
@@ -208,11 +208,18 @@ impl<const N: usize> NodeStorage<N> for RocksDBNodeStorage<N> {
 
     fn insert_blob(&mut self, hash: ValueDigest<N>, bytes: &[u8]) -> Result<(), StorageError> {
         let db_key = Self::blob_key(&hash);
-        // Content-addressed: if the key is already present, skip writing.
-        // Avoids needlessly bumping RocksDB write counters on repeated
-        // inserts of the same blob.
-        if self.db.get(&db_key).ok().flatten().is_some() {
-            return Ok(());
+        match self
+            .db
+            .get(&db_key)
+            .map_err(|e| StorageError::Other(e.to_string()))?
+        {
+            Some(existing) if existing == bytes => return Ok(()),
+            Some(_) => {
+                return Err(StorageError::Other(format!(
+                    "blob {hash:x} already exists with different bytes"
+                )));
+            }
+            None => {}
         }
         self.db
             .put(&db_key, bytes)

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -91,13 +91,16 @@ impl<const N: usize> NodeStorage<N> for InMemoryNodeStorage<N> {
     }
 
     fn insert_blob(&mut self, hash: ValueDigest<N>, bytes: &[u8]) -> Result<(), StorageError> {
-        // Content-addressed: if the hash is already present, leave it alone.
-        // `entry().or_insert_with()` avoids an unnecessary `to_vec()` clone
-        // when the blob already exists.
         let mut blobs = self.blobs.write();
-        blobs
-            .entry(hash)
-            .or_insert_with(|| Arc::new(bytes.to_vec()));
+        if let Some(existing) = blobs.get(&hash) {
+            if existing.as_slice() == bytes {
+                return Ok(());
+            }
+            return Err(StorageError::Other(format!(
+                "blob {hash:x} already exists with different bytes"
+            )));
+        }
+        blobs.insert(hash, Arc::new(bytes.to_vec()));
         Ok(())
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -144,9 +144,9 @@ pub trait NodeStorage<const N: usize>: Send + Sync + Clone {
     // Default impls return `BlobNotSupported` so a backend that doesn't yet
     // implement them fails loudly rather than silently dropping data.
 
-    /// Persist raw bytes under `hash`. Idempotent — if `hash` is already
-    /// present, the call must be a no-op (content-addressed: same hash
-    /// implies same content).
+    /// Persist raw bytes under `hash`. Idempotent when the existing bytes
+    /// match. If `hash` already exists with different bytes, implementations
+    /// must report an error instead of accepting the mismatch.
     fn insert_blob(&mut self, hash: ValueDigest<N>, bytes: &[u8]) -> Result<(), StorageError> {
         let _ = (hash, bytes);
         Err(StorageError::Other(

--- a/tests/blob_storage.rs
+++ b/tests/blob_storage.rs
@@ -28,7 +28,7 @@ limitations under the License.
 
 use prollytree::digest::ValueDigest;
 use prollytree::node::ProllyNode;
-use prollytree::storage::{FileNodeStorage, NodeStorage};
+use prollytree::storage::{FileNodeStorage, InMemoryNodeStorage, NodeStorage};
 use tempfile::TempDir;
 
 const N: usize = 32;
@@ -129,6 +129,26 @@ fn file_large_blob_round_trip() {
 }
 
 // ---------------------------------------------------------------------------
+// In-memory backend
+// ---------------------------------------------------------------------------
+
+#[test]
+fn memory_blob_insert_existing_mismatch_errors() {
+    let mut s = InMemoryNodeStorage::<N>::new();
+    let hash = h(b"correct");
+    s.insert_blob(hash.clone(), b"correct").unwrap();
+
+    let err = s
+        .insert_blob(hash.clone(), b"wrong")
+        .expect_err("same hash with different bytes must not report success");
+    assert!(
+        err.to_string().contains("already exists"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(s.get_blob(&hash).as_deref(), Some(b"correct" as &[u8]));
+}
+
+// ---------------------------------------------------------------------------
 // RocksDB backend
 // ---------------------------------------------------------------------------
 
@@ -164,6 +184,23 @@ mod rocksdb_backend {
         s.insert_blob(hash.clone(), b"v").unwrap();
         s.insert_blob(hash.clone(), b"v").unwrap();
         assert_eq!(s.get_blob(&hash).as_deref(), Some(b"v" as &[u8]));
+    }
+
+    #[test]
+    fn rocksdb_blob_insert_existing_mismatch_errors() {
+        let temp = TempDir::new().unwrap();
+        let mut s = RocksDBNodeStorage::<N>::new(temp.path().to_path_buf()).unwrap();
+        let hash = h(b"correct");
+        s.insert_blob(hash.clone(), b"correct").unwrap();
+
+        let err = s
+            .insert_blob(hash.clone(), b"wrong")
+            .expect_err("same hash with different bytes must not report success");
+        assert!(
+            err.to_string().contains("already exists"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(s.get_blob(&hash).as_deref(), Some(b"correct" as &[u8]));
     }
 
     #[test]


### PR DESCRIPTION
Isolated fix off current `main`, no unrelated changes. Includes a regression test.