### PR TITLE
fix(git): preserve staging on failed commit

### DIFF
--- a/src/git/versioned_store/core.rs
+++ b/src/git/versioned_store/core.rs
@@ -278,40 +278,67 @@ where
 
     /// Commit staged changes
     pub fn commit(&mut self, message: &str) -> Result<gix::ObjectId, GitKvError> {
+        let original_tree = self.tree.clone();
+        let original_staging_area = self.staging_area.clone();
+
         // Apply staged changes in a single batch so we run the streaming
         // canonical chunker once per commit instead of once per staged item.
-        let changes: Vec<(Vec<u8>, Option<Vec<u8>>)> = self.staging_area.drain().collect();
+        let changes: Vec<(Vec<u8>, Option<Vec<u8>>)> =
+            original_staging_area.clone().into_iter().collect();
         self.tree.apply_changes(changes);
 
-        // Persist the tree state (including updating root hash and saving config)
-        self.tree.persist_root();
+        let commit_result = (|| {
+            // Persist the tree state (including updating root hash and saving config)
+            self.tree.persist_root();
 
-        // For all storage types, also save the tree config to git for historical access
-        self.save_tree_config_to_git_internal()?;
+            // For all storage types, also save the tree config to git for historical access
+            self.save_tree_config_to_git_internal()?;
 
-        // Get the git root directory using work_dir() for worktree/submodule compatibility
-        let dataset_dir = self
-            .dataset_dir
-            .as_ref()
-            .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".into()))?;
-        let git_root = self
-            .metadata
-            .work_dir()
-            .or_else(|| Self::find_git_root(dataset_dir))
-            .ok_or_else(|| GitKvError::GitObjectError("Could not find git root".into()))?;
+            // Get the git root directory using work_dir() for worktree/submodule compatibility
+            let dataset_dir = self
+                .dataset_dir
+                .as_ref()
+                .ok_or_else(|| GitKvError::GitObjectError("Dataset directory not set".into()))?;
+            let git_root = self
+                .metadata
+                .work_dir()
+                .or_else(|| Self::find_git_root(dataset_dir))
+                .ok_or_else(|| GitKvError::GitObjectError("Could not find git root".into()))?;
 
-        // Stage and write tree via metadata backend
-        let tree_id = self.metadata.stage_and_write_tree(&git_root)?;
+            // Stage and write tree via metadata backend
+            let tree_id = self.metadata.stage_and_write_tree(&git_root)?;
 
-        // Create commit via metadata backend
-        let commit_id = self.metadata.write_commit(tree_id, message)?;
+            // Create commit via metadata backend
+            let commit_id = self.metadata.write_commit(tree_id, message)?;
 
-        // Update branch ref and HEAD
-        self.metadata
-            .update_branch(&self.current_branch, commit_id)?;
-        self.metadata.update_head(&self.current_branch)?;
+            // Update branch ref and HEAD
+            self.metadata
+                .update_branch(&self.current_branch, commit_id)?;
+            self.metadata.update_head(&self.current_branch)?;
+
+            Ok(commit_id)
+        })();
+
+        let commit_id = match commit_result {
+            Ok(commit_id) => commit_id,
+            Err(err) => {
+                self.tree = original_tree;
+                self.staging_area = original_staging_area;
+                let staging_restore = self.save_staging_area();
+                let _ = self.save_tree_config_to_git_internal();
+
+                if let Err(restore_err) = staging_restore {
+                    return Err(GitKvError::GitObjectError(format!(
+                        "{err}; additionally failed to restore staging area after aborted commit: {restore_err}"
+                    )));
+                }
+
+                return Err(err);
+            }
+        };
 
         // Clear staging area file since we've committed
+        self.staging_area.clear();
         self.save_staging_area()?;
 
         Ok(commit_id)

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -324,6 +324,56 @@ mod tests {
     }
 
     #[test]
+    fn failed_commit_preserves_staging_and_committed_head() {
+        let temp_dir = TempDir::new().unwrap();
+
+        gix::init(temp_dir.path()).unwrap();
+
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git config name failed");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git config email failed");
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+        let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+
+        store.insert(b"key1".to_vec(), b"value1".to_vec()).unwrap();
+
+        let config_path = dataset_dir.join("prolly_config_tree_config");
+        std::fs::remove_file(&config_path).unwrap();
+        std::fs::create_dir(&config_path).unwrap();
+
+        let err = store
+            .commit("commit should fail")
+            .expect_err("config write failure should abort commit");
+        assert!(
+            err.to_string().contains("Failed to write config file"),
+            "unexpected error: {err}"
+        );
+
+        let status = store.status();
+        assert_eq!(
+            status,
+            vec![(b"key1".to_vec(), "added".to_string())],
+            "failed commit must leave the staged change available to retry"
+        );
+
+        let head_keys = store.get_keys_at_ref("HEAD").unwrap();
+        assert!(
+            !head_keys.contains_key(&b"key1".to_vec()),
+            "failed commit must not advance committed history"
+        );
+    }
+
+    #[test]
     fn test_single_commit_behavior() {
         let temp_dir = TempDir::new().unwrap();
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -312,7 +312,7 @@ impl Default for TreeStats {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProllyTree<const N: usize, S: NodeStorage<N>> {
     pub root: ProllyNode<N>,
     pub storage: S,


### PR DESCRIPTION
# Commit Failure Preserves Staging

## Bug

`VersionedKvStore::commit` drained the staging area and applied staged changes
to the in-memory tree before running fallible persistence and Git commit steps.
If one of those later steps failed, the current handle lost the staged changes
even though no commit had been created.

## Impact

A transient filesystem or Git error could turn a failed commit into an ambiguous
state: `status()` reported no staged changes, while the committed history had
not advanced. Users could not reliably retry the commit from the same handle and
could mistake the failed write for a successful one.

## Fix

The commit path now snapshots the tree and staging area before applying staged
changes. If any fallible commit step fails before success, it restores the
original in-memory tree and staging map, rewrites the staging file when possible,
and returns the original error. Staging is cleared only after the commit object,
branch update, and HEAD update succeed.

## Regression Proof

The branch adds `failed_commit_preserves_staging_and_committed_head` in
`src/git/versioned_store/tests.rs`. The test stages one key, replaces
`dataset/prolly_config_tree_config` with a directory so config persistence
fails, and asserts the failed commit leaves the key staged while `HEAD` still
does not contain it.

Against the pre-fix implementation, `status()` returned an empty list after the
failed commit. The fixed branch preserves the staged key as `added`.

## Verification

Verified on `fix/commit-preserves-staging-on-failure` during the bug-fix
campaign:

- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-commit-atomicity-target /opt/homebrew/bin/cargo test --lib --features git failed_commit_preserves_staging_and_committed_head -- --nocapture`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-commit-atomicity-target /opt/homebrew/bin/cargo test --lib --features git git::versioned_store::tests -- --nocapture`
