### PR TITLE
fix(node): terminate on degenerate TreeConfig instead of hanging

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -543,7 +543,21 @@ impl<const N: usize> ProllyNode<N> {
                 .map(|n| n.get_hash().as_bytes().to_vec())
                 .collect();
 
-            current = build_level(&next_keys, &next_values, false, level, config);
+            let prev_len = current.len();
+            let next = build_level(&next_keys, &next_values, false, level, config);
+
+            // Convergence guarantee. Every sane `TreeConfig` fans in (each internal
+            // level has strictly fewer nodes than the level below), so this branch
+            // is never taken. A pathological config (e.g. one whose chunker always
+            // emits size-1 chunks - `pattern == 0` with `max_chunk_size == 0`) would
+            // otherwise produce a level no smaller than the previous one and loop
+            // forever. Collapsing the whole level into a single wide root terminates
+            // the build with a valid (if uncompressed) tree instead of hanging.
+            current = if next.len() >= prev_len {
+                vec![make_node(next_keys, next_values, false, level, config)]
+            } else {
+                next
+            };
         }
 
         current
@@ -627,12 +641,20 @@ impl<const N: usize> NodeChunk for ProllyNode<N> {
         if self.keys.len() < self.min_chunk_size {
             return Vec::new();
         }
+        // Guarantee forward progress. A degenerate `min_chunk_size == 0` makes the
+        // window `start..start` empty, so `end` never advances past `last_start` and
+        // the outer loop spins forever emitting empty chunks (hang / OOM). Flooring
+        // the effective window at 1 preserves behaviour for every sane config
+        // (`min_chunk_size >= 1`, where `min == self.min_chunk_size`) while ensuring
+        // each emitted chunk covers at least one entry so `last_start` strictly
+        // increases and the loop terminates.
+        let min = self.min_chunk_size.max(1);
         let mut chunks = Vec::new();
         let mut start = 0;
         let mut last_start = 0;
 
         while start < self.keys.len() {
-            let mut end = start + self.min_chunk_size;
+            let mut end = start + min;
 
             // Ensure that 'end' does not exceed the length of the keys vector
             if end > self.keys.len() {

--- a/tests/regression_degenerate_config.rs
+++ b/tests/regression_degenerate_config.rs
@@ -1,0 +1,91 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Regression: a degenerate `TreeConfig` must not hang the chunker/tree builder.
+//!
+//! With `min_chunk_size == 0` (and `pattern == 0` / `max_chunk_size == 0`) two
+//! separate loops used to spin forever: `chunk_content` emitted empty chunks, and
+//! `build_canonical_from_pairs` never fanned in (size-1 chunks -> each tree level
+//! the same size as the one below). Both are reachable through the public
+//! `ProllyNode::build_canonical_from_pairs` / `TreeConfig` surface. The fix floors
+//! the effective window at 1 and collapses a non-shrinking level into a single root.
+
+use prollytree::config::TreeConfig;
+use prollytree::node::ProllyNode;
+use prollytree::storage::InMemoryNodeStorage;
+use prollytree::tree::{ProllyTree, Tree};
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// Runs the degenerate build in a worker thread with a hard timeout so a
+/// regression FAILS the test instead of hanging the whole suite.
+#[test]
+fn bug_degenerate_min_chunk_size_terminates_not_hang() {
+    let (tx, rx) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        let mut storage = InMemoryNodeStorage::<32>::default();
+        let config = TreeConfig::<32> {
+            min_chunk_size: 0,
+            max_chunk_size: 0,
+            pattern: 0,
+            ..TreeConfig::default()
+        };
+        let pairs: Vec<(Vec<u8>, Vec<u8>)> = (0..50u32)
+            .map(|i| (format!("k{i:04}").into_bytes(), b"v".to_vec()))
+            .collect();
+        let root = ProllyNode::build_canonical_from_pairs(pairs, &config, &mut storage);
+        let _ = tx.send(root.keys.len());
+    });
+
+    match rx.recv_timeout(Duration::from_secs(15)) {
+        Ok(_) => {
+            let _ = worker.join();
+        }
+        Err(_) => {
+            panic!("chunk_content did not terminate with min_chunk_size=0 (infinite-loop regression)")
+        }
+    }
+}
+
+/// Every emitted chunk from a degenerate zero-min config must still be non-empty
+/// and the pairs must survive the round trip (no dropped/duplicated keys).
+#[test]
+fn bug_degenerate_config_preserves_all_keys() {
+    let mut storage = InMemoryNodeStorage::<32>::default();
+    let config = TreeConfig::<32> {
+        min_chunk_size: 0,
+        max_chunk_size: 0,
+        pattern: 0,
+        ..TreeConfig::default()
+    };
+    let pairs: Vec<(Vec<u8>, Vec<u8>)> = (0..200u32)
+        .map(|i| (format!("k{i:04}").into_bytes(), format!("v{i}").into_bytes()))
+        .collect();
+    let root = ProllyNode::build_canonical_from_pairs(pairs.clone(), &config, &mut storage);
+
+    let tree = ProllyTree {
+        root,
+        storage,
+        config,
+    };
+    for (k, _) in &pairs {
+        assert!(
+            tree.find(k).is_some(),
+            "key {:?} dropped by degenerate-config build",
+            String::from_utf8_lossy(k)
+        );
+    }
+}


### PR DESCRIPTION
# Degenerate TreeConfig Hang

## Bug

Degenerate `TreeConfig` values could make tree construction loop forever. When
`min_chunk_size` was zero, `chunk_content` could repeatedly emit empty chunks.
Separately, when the effective chunking configuration failed to reduce a level
of nodes, `build_canonical_from_pairs` kept rebuilding the same-sized level
inside `while current.len() > 1`.

## Impact

The bug was reachable through public configuration fields. A caller could create
a tree with a malformed but accepted config and then hang or exhaust memory while
building the tree. That is a denial-of-service style failure for any service that
accepts or constructs tree configs dynamically.

## Fix

The chunking path now floors the effective minimum chunk size at one, so it
cannot repeatedly produce empty chunks. The canonical builder also detects a
non-shrinking level and collapses it into a single root instead of looping. Normal
configurations keep the existing canonical output; the fallback only applies
when the config cannot fan in.

## Regression Proof

`tests/regression_degenerate_config.rs` contains two focused regressions:

- `bug_degenerate_min_chunk_size_terminates_not_hang`
- `bug_degenerate_config_preserves_all_keys`

Together they prove the degenerate config terminates and that the resulting tree
still preserves inserted keys.

Against the pre-fix implementation, the timeout-guarded regression does not
complete. The fixed branch completes the regression and preserves lookup
behavior.

## Verification

Verified on `fix/degenerate-config-hang` with the focused regression file and
the branch's cargo quality gates during the bug-fix campaign:

- `cargo test --test regression_degenerate_config`
- `cargo test --features "git sql proximity"`
- `cargo build --all`
- `cargo clippy --all`
- `cargo fmt --all -- --check`
