### PR TITLE
fix(history): error on corrupt file key history

### DIFF
--- a/src/git/versioned_store/history.rs
+++ b/src/git/versioned_store/history.rs
@@ -176,18 +176,9 @@ where
         let mut previous_value: Option<Vec<u8>> = None; // None = key not present, Some(val) = key present with value
 
         for commit in commit_history {
-            // Get the key value at this commit by reconstructing tree state
-            let current_value = {
-                if let Ok(tree_config) = self.read_tree_config_from_commit(&commit.id) {
-                    if let Ok(keys_at_commit) = self.collect_keys_from_config(&tree_config) {
-                        keys_at_commit.get(key).cloned()
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            };
+            let tree_config = self.read_tree_config_from_commit(&commit.id)?;
+            let keys_at_commit = self.collect_keys_from_config(&tree_config)?;
+            let current_value = keys_at_commit.get(key).cloned();
 
             // Check if the value changed from the previous commit
             let value_changed = previous_value != current_value;

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -681,6 +681,55 @@ mod tests {
     }
 
     #[test]
+    fn file_get_commits_reports_missing_historical_child_node() {
+        let temp_dir = TempDir::new().unwrap();
+        gix::init(temp_dir.path()).unwrap();
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = FileVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+        store.tree.config.min_chunk_size = 2;
+        store.tree.config.max_chunk_size = 2;
+        store.tree.config.pattern = 0;
+        for i in 0..8 {
+            store
+                .insert(
+                    format!("key{i:02}").into_bytes(),
+                    format!("value{i:02}").into_bytes(),
+                )
+                .unwrap();
+        }
+        store.commit("Add multi-level data").unwrap();
+
+        assert!(
+            !store.tree.root.is_leaf,
+            "test setup must create an internal root"
+        );
+        let child_hash = crate::digest::ValueDigest::<32>::raw_hash(&store.tree.root.values[0]);
+        let child_path = temp_dir
+            .path()
+            .join(".git")
+            .join("prolly")
+            .join("nodes")
+            .join("files")
+            .join(format!("{child_hash:x}"));
+        std::fs::remove_file(child_path).unwrap();
+
+        let err = match store.get_commits(b"key00") {
+            Ok(commits) => panic!(
+                "history lookup with a missing historical child node must fail, got {commits:?}"
+            ),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("child") || err.to_string().contains("Child"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn test_get_commits_with_repeated_changes() {
         let temp_dir = TempDir::new().unwrap();
 


### PR DESCRIPTION
# File History Lookup Errors On Missing Child Nodes

## Bug

`HistoricalCommitAccess::get_commits_for_key` for file-backed stores used the
generic `get_commits_for_key_generic` helper. That helper reconstructed each
historical tree state, but converted any reconstruction error into `None` for
the requested key.

## Impact

If a committed file-backed tree had a root hash whose descendant node file was
missing, key-history lookup returned a normal result such as `Ok([])`. Callers
could interpret repository corruption as "this key never changed" instead of
seeing an integrity failure.

## Fix

The generic key-history helper now propagates errors from
`read_tree_config_from_commit` and `collect_keys_from_config`. Commits with no
tree config still use the existing default empty config path, but commits that
advertise a root hash and cannot reconstruct that tree now fail.

## Regression Proof

The branch adds `file_get_commits_reports_missing_historical_child_node` in
`src/git/versioned_store/tests.rs`. The test creates a multi-level file-backed
tree, commits it, removes one persisted child node file, then calls
`get_commits(b"key00")`.

Against `main`, the test failed because the API returned `Ok([])`. The fixed
branch returns an error mentioning the missing child node.

## Verification

Run on `fix/file-get-commits-missing-child-node`:

- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-get-commits-missing-child-target /opt/homebrew/bin/cargo test --lib --features git file_get_commits_reports_missing_historical_child_node -- --nocapture`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-get-commits-missing-child-target /opt/homebrew/bin/cargo test --lib --features git git::versioned_store::tests -- --nocapture`
- `/opt/homebrew/bin/cargo fmt --all -- --check`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-get-commits-missing-child-target /opt/homebrew/bin/cargo build --all`
- `timeout 240 zsh -lc 'CARGO_TARGET_DIR=/tmp/prollytree-get-commits-missing-child-clippy-target /opt/homebrew/bin/cargo clippy --all -q; rc=$?; echo CLIPPY_STATUS:$rc; exit $rc'`
