### PR TITLE
fix(git): fail open on missing persistent roots

### DIFF
--- a/src/git/versioned_store/backends.rs
+++ b/src/git/versioned_store/backends.rs
@@ -1077,7 +1077,7 @@ impl<const N: usize> VersionedKvStore<N, FileNodeStorage<N>, GitMetadataBackend>
             ));
         }
 
-        let storage = FileNodeStorage::<N>::new(file_storage_path.clone()).map_err(|e| {
+        let storage = FileNodeStorage::<N>::new(file_storage_path).map_err(|e| {
             GitKvError::GitObjectError(format!("Failed to create file storage: {e}"))
         })?;
 
@@ -1096,17 +1096,19 @@ impl<const N: usize> VersionedKvStore<N, FileNodeStorage<N>, GitMetadataBackend>
         let config: TreeConfig<N> = serde_json::from_str(&config_data)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to parse config file: {e}")))?;
 
-        // Try to load existing tree from storage using the config's root hash
-        let tree =
-            if let Some(existing_tree) = ProllyTree::load_from_storage(storage, config.clone()) {
-                existing_tree
-            } else {
-                // Create new storage instance since the original was consumed
-                let new_storage = FileNodeStorage::<N>::new(file_storage_path).map_err(|e| {
-                    GitKvError::GitObjectError(format!("Failed to create file storage: {e}"))
-                })?;
-                ProllyTree::new(new_storage, config)
-            };
+        // Existing persistent stores must have their saved root available.
+        // Falling back to an empty tree would hide data loss and let a later
+        // commit overwrite the dataset with an empty root.
+        let root_hash = config
+            .root_hash
+            .as_ref()
+            .map(|hash| format!("{hash:x}"))
+            .unwrap_or_else(|| "<missing>".to_string());
+        let tree = ProllyTree::load_from_storage(storage, config).ok_or_else(|| {
+            GitKvError::GitObjectError(format!(
+                "Failed to load file store root node {root_hash} from storage"
+            ))
+        })?;
 
         // Get current branch
         let current_branch = git_repo
@@ -1292,9 +1294,19 @@ impl<const N: usize> VersionedKvStore<N, RocksDBNodeStorage<N>, GitMetadataBacke
         let config: TreeConfig<N> = serde_json::from_str(&config_data)
             .map_err(|e| GitKvError::GitObjectError(format!("Failed to parse config file: {e}")))?;
 
-        // Try to load existing tree from storage using the config's root hash
-        let tree = ProllyTree::load_from_storage(storage.clone(), config.clone())
-            .unwrap_or_else(|| ProllyTree::new(storage, config));
+        // Existing persistent stores must have their saved root available.
+        // Falling back to an empty tree would hide data loss and let a later
+        // commit overwrite the dataset with an empty root.
+        let root_hash = config
+            .root_hash
+            .as_ref()
+            .map(|hash| format!("{hash:x}"))
+            .unwrap_or_else(|| "<missing>".to_string());
+        let tree = ProllyTree::load_from_storage(storage, config).ok_or_else(|| {
+            GitKvError::GitObjectError(format!(
+                "Failed to load RocksDB store root node {root_hash} from storage"
+            ))
+        })?;
 
         // Get current branch
         let current_branch = git_repo

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -226,6 +226,7 @@ mod tests {
         FileVersionedKvStore, GitVersionedKvStore, HistoricalAccess, HistoricalCommitAccess,
         InMemoryVersionedKvStore, ThreadSafeGitVersionedKvStore,
     };
+    use crate::tree::Tree;
     use tempfile::TempDir;
 
     /// RAII guard that holds the global CWD mutex and restores the working
@@ -811,6 +812,37 @@ mod tests {
             let key1_commits = store.get_commits(b"key1").unwrap();
             assert!(!key1_commits.is_empty());
         }
+    }
+
+    #[test]
+    fn file_open_reports_missing_root_node() {
+        let temp_dir = TempDir::new().unwrap();
+        gix::init(temp_dir.path()).unwrap();
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir_all(&dataset_dir).unwrap();
+        {
+            let _cwd = CwdGuard::set(&dataset_dir);
+            let mut store = FileVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+            store.insert(b"key1".to_vec(), b"value1".to_vec()).unwrap();
+            store.commit("Add data").unwrap();
+
+            let root_hash = store.tree.get_root_hash().expect("root hash after commit");
+            let root_path = temp_dir
+                .path()
+                .join(".git")
+                .join("prolly")
+                .join("nodes")
+                .join("files")
+                .join(format!("{root_hash:x}"));
+            std::fs::remove_file(root_path).unwrap();
+        }
+
+        let err = match FileVersionedKvStore::<32>::open(&dataset_dir) {
+            Ok(_) => panic!("opening a store with a missing root node must fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("root"), "unexpected error: {err}");
     }
 
     #[test]


### PR DESCRIPTION
# Persistent Open Errors On Missing Root Nodes

## Bug

`FileVersionedKvStore::open` loaded the saved tree config, tried to load the
configured root node, and silently constructed a new empty `ProllyTree` when the
root node was missing. The RocksDB-backed open path had the same fallback.

## Impact

A persistent store with a valid config but missing node storage could open
successfully as an empty tree. Callers would see missing data instead of an
integrity error, and a later commit could persist the empty tree over the
dataset's previous state.

## Fix

Persistent open paths now require the saved root to load from node storage.
If the config has no root hash or the referenced root node is unavailable,
`open` returns `GitObjectError` naming the missing root instead of fabricating an
empty tree.

## Regression Proof

The branch adds `file_open_reports_missing_root_node` in
`src/git/versioned_store/tests.rs`. The test creates a File-backed store,
commits one key, deletes the persisted root node from
`.git/prolly/nodes/files/`, then calls `FileVersionedKvStore::open`.

Against the pre-fix implementation, `open` returned `Ok(_)`. The fixed branch
returns an error mentioning the root node.

## Verification

Run on `fix/file-open-missing-root-node`:

- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-file-open-root-target /opt/homebrew/bin/cargo test --lib --features git file_open_reports_missing_root_node -- --nocapture`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-file-open-root-target /opt/homebrew/bin/cargo test --lib --features git git::versioned_store::tests -- --nocapture`
- `/opt/homebrew/bin/cargo fmt --all -- --check`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-file-open-root-target /opt/homebrew/bin/cargo build --all`
- `timeout 240 zsh -lc 'CARGO_TARGET_DIR=/tmp/prollytree-file-open-root-clippy-target /opt/homebrew/bin/cargo clippy --all -q; rc=$?; echo CLIPPY_STATUS:$rc; exit $rc'`
