### PR TITLE
fix(storage): write file nodes and configs atomically

### DIFF
--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -16,7 +16,7 @@ use crate::digest::ValueDigest;
 use crate::node::ProllyNode;
 use std::fs::{self, File};
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -65,6 +65,39 @@ impl<const N: usize> FileNodeStorage<N> {
     fn blob_path(&self, hash: &ValueDigest<N>) -> PathBuf {
         self.blobs_dir().join(format!("{hash:x}"))
     }
+
+    fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), StorageError> {
+        let Some(parent) = path.parent() else {
+            return Err(StorageError::Other(format!(
+                "cannot write path without parent: {}",
+                path.display()
+            )));
+        };
+        fs::create_dir_all(parent)?;
+
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| StorageError::Other(format!("invalid path: {}", path.display())))?;
+        let tmp_path = parent.join(format!("{name}.partial.{}", unique_suffix()));
+        let mut file = File::create(&tmp_path)?;
+        let result = (|| -> Result<(), StorageError> {
+            file.write_all(bytes)?;
+            file.sync_all()?;
+            drop(file);
+            fs::rename(&tmp_path, path)?;
+            // Best-effort directory sync: required for crash durability on
+            // filesystems that support it, harmlessly skipped elsewhere.
+            if let Ok(dir) = File::open(parent) {
+                let _ = dir.sync_all();
+            }
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&tmp_path);
+        }
+        result
+    }
 }
 
 impl<const N: usize> NodeStorage<N> for FileNodeStorage<N> {
@@ -89,9 +122,7 @@ impl<const N: usize> NodeStorage<N> for FileNodeStorage<N> {
     ) -> Result<(), StorageError> {
         let path = self.node_path(&hash);
         let data = crate::serde_bincode::serialize(&node)?;
-        let mut file = File::create(path)?;
-        file.write_all(&data)?;
-        Ok(())
+        Self::atomic_write(&path, &data)
     }
 
     fn delete_node(&mut self, hash: &ValueDigest<N>) -> Result<(), StorageError> {
@@ -104,9 +135,7 @@ impl<const N: usize> NodeStorage<N> for FileNodeStorage<N> {
 
     fn save_config(&self, key: &str, config: &[u8]) {
         let path = self.config_path(key);
-        if let Ok(mut file) = File::create(path) {
-            let _ = file.write_all(config);
-        }
+        let _ = Self::atomic_write(&path, config);
     }
 
     fn get_config(&self, key: &str) -> Option<Vec<u8>> {

--- a/tests/file_storage_atomicity.rs
+++ b/tests/file_storage_atomicity.rs
@@ -1,0 +1,104 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use prollytree::node::ProllyNode;
+use prollytree::storage::{FileNodeStorage, NodeStorage};
+use tempfile::TempDir;
+
+#[test]
+fn file_node_storage_round_trips_node_and_config() {
+    let temp = TempDir::new().unwrap();
+    let mut storage = FileNodeStorage::<32>::new(temp.path().to_path_buf()).unwrap();
+
+    let mut node = ProllyNode::<32>::default();
+    node.keys = vec![b"key".to_vec()];
+    node.values = vec![b"value".to_vec()];
+    let hash = node.get_hash();
+
+    storage.insert_node(hash.clone(), node.clone()).unwrap();
+    storage.save_config("tree", b"config-bytes");
+
+    assert_eq!(
+        storage
+            .get_node_by_hash(&hash)
+            .map(|stored| stored.keys.clone()),
+        Some(node.keys)
+    );
+    assert_eq!(
+        storage.get_config("tree").as_deref(),
+        Some(&b"config-bytes"[..])
+    );
+}
+
+#[cfg(unix)]
+mod unix_atomicity {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn insert_node_replaces_bad_final_path_without_writing_through_it() {
+        let temp = TempDir::new().unwrap();
+        let blocked_target = temp.path().join("blocked-target");
+        fs::create_dir(&blocked_target).unwrap();
+
+        let mut storage = FileNodeStorage::<32>::new(temp.path().to_path_buf()).unwrap();
+        let mut node = ProllyNode::<32>::default();
+        node.keys = vec![b"atomic-key".to_vec()];
+        node.values = vec![b"atomic-value".to_vec()];
+        let hash = node.get_hash();
+        let node_path = temp.path().join(format!("{hash:x}"));
+        symlink(&blocked_target, &node_path).unwrap();
+
+        storage.insert_node(hash.clone(), node.clone()).unwrap();
+
+        assert!(
+            !fs::symlink_metadata(&node_path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "atomic rename should replace the bad final-path symlink"
+        );
+        assert_eq!(
+            storage
+                .get_node_by_hash(&hash)
+                .map(|stored| stored.values.clone()),
+            Some(node.values)
+        );
+    }
+
+    #[test]
+    fn save_config_replaces_bad_final_path_without_writing_through_it() {
+        let temp = TempDir::new().unwrap();
+        let blocked_target = temp.path().join("blocked-target");
+        fs::create_dir(&blocked_target).unwrap();
+        let config_path = temp.path().join("config_tree");
+        symlink(&blocked_target, &config_path).unwrap();
+
+        let storage = FileNodeStorage::<32>::new(temp.path().to_path_buf()).unwrap();
+        storage.save_config("tree", b"atomic-config");
+
+        assert!(
+            !fs::symlink_metadata(&config_path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "atomic rename should replace the bad final-path symlink"
+        );
+        assert_eq!(
+            storage.get_config("tree").as_deref(),
+            Some(&b"atomic-config"[..])
+        );
+    }
+}


### PR DESCRIPTION
# File Storage Atomic Writes

## Bug

`FileNodeStorage::insert_node` and `save_config` wrote directly to their final
paths with `File::create` and `write_all`. If a process crashed, the machine lost
power, or a write failed midway, the final node/config file could be truncated or
partially written. Blob writes in the same backend already used a safer
temporary-file plus rename pattern, but nodes and config did not.

## Impact

A truncated node file makes a persisted tree root unloadable: later reads fail
to deserialize the node and the tree can appear missing or corrupt. A truncated
config can similarly break reopen behavior. Because this storage backend is a
durable on-disk backend, partial final-path writes are a correctness and data
survivability bug.

## Fix

Node and config writes now follow the existing blob durability pattern: write to
a unique temporary path, flush/sync the file, atomically rename it into place,
and sync the parent directory where supported. Existing successful writes keep
the same final layout; only the write protocol changes.

## Regression Proof

`tests/file_storage_atomicity.rs` exercises node and config write behavior
through a file-backed temporary store. It verifies that writes round-trip and
that the backend replaces bad final paths via the atomic write path instead of
writing through existing corrupt files.

Against the pre-fix implementation, final-path write behavior could leave a
truncated node/config visible at the canonical path. The fixed branch routes
node and config writes through the same atomic replacement discipline as blobs.

## Verification

Verified on `fix/file-storage-atomic-writes` during the bug-fix campaign:

- `cargo test --test file_storage_atomicity`
- `cargo test --features "git sql proximity"`
- `cargo build --all`
- `cargo clippy --all`
- `cargo fmt --all -- --check`
