### PR TITLE
fix(storage): preserve historical externalized blobs

### DIFF
--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -43,7 +43,7 @@ use crate::storage::{GitNodeStorage, InMemoryNodeStorage, NodeStorage};
 use crate::tree::{ProllyTree, Tree};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -95,6 +95,7 @@ pub struct MigrationReport {
 
 /// The default namespace name used for backward-compatible flat API calls.
 pub const DEFAULT_NAMESPACE: &str = "default";
+const NAMESPACED_REGISTRY_FILENAME: &str = "prolly_namespace_registry";
 
 /// Type alias for the per-target value transformer closure used by cascade.
 /// Takes the raw primary-tree value bytes and returns `Some(text)` to embed,
@@ -251,12 +252,11 @@ impl<'a, const N: usize, S: NodeStorage<N>, M: MetadataBackend> NamespaceHandle<
         }
 
         // Check committed tree. Raw bytes from the leaf may be an externalised
-        // envelope; unwrap_value handles both cases (inline pass-through plus
-        // graceful fallback when an envelope-shaped value's hash doesn't
-        // resolve to a real blob).
+        // envelope; unwrap_value handles inline pass-through and returns None
+        // if an envelope's blob is missing instead of exposing envelope bytes.
         if let Some(tree) = self.store.namespaces.get(&self.ns_name) {
             return tree.find(key).and_then(|node| {
-                node.keys.iter().position(|k| k == key).map(|idx| {
+                node.keys.iter().position(|k| k == key).and_then(|idx| {
                     crate::storage::externalize::unwrap_value::<N, _>(
                         &node.values[idx],
                         &self.store.inner.tree.storage,
@@ -711,18 +711,17 @@ where
         &self.inner.tree.storage
     }
 
-    /// Walk every loaded namespace, collect all blob hashes referenced by
-    /// envelope-shaped leaf values, and delete every blob in storage that
-    /// isn't on that list.
+    /// Walk every loaded namespace and every reachable commit, collect all
+    /// blob hashes referenced by envelope-shaped leaf values, and delete every
+    /// blob in storage that isn't on that list.
     ///
     /// Loads every namespace listed in the registry first, so blobs
     /// referenced by namespaces the user hasn't explicitly opened are still
     /// preserved.
     ///
-    /// **Scope caveat:** GC walks only the current HEAD state. Blobs
-    /// referenced by older commits but not by HEAD are deleted, so checking
-    /// out an old commit after GC may fail to retrieve those values.
-    /// History-aware GC (walking all reachable commits) is a future PR.
+    /// The historical walk starts at HEAD and all branch heads exposed by the
+    /// metadata backend. If a historical namespace root cannot be loaded, GC
+    /// fails before deleting anything.
     pub fn gc_blobs(&mut self) -> Result<BlobGcReport, GitKvError> {
         // 1. Ensure every namespace from the registry is loaded in memory.
         let ns_names = self.list_namespaces();
@@ -733,24 +732,23 @@ where
         // 2. Walk every loaded namespace tree, collect referenced blob hashes.
         let mut referenced: HashSet<ValueDigest<N>> = HashSet::new();
         for tree in self.namespaces.values() {
-            for key in tree.collect_keys() {
-                let raw = tree.find(&key).and_then(|node| {
-                    node.keys
-                        .iter()
-                        .position(|k| k == &key)
-                        .map(|i| node.values[i].clone())
-                });
-                if let Some(bytes) = raw {
-                    if let Some((hash, _size)) =
-                        crate::storage::externalize::parse_envelope::<N>(&bytes)
-                    {
-                        referenced.insert(hash);
-                    }
-                }
+            Self::collect_referenced_blobs_from_tree(tree, &mut referenced);
+        }
+
+        // 3. Also preserve blobs referenced by any namespace root reachable
+        // from HEAD or a branch head. Otherwise GC can make old commits unreadable.
+        for commit_id in self.reachable_commit_ids()? {
+            let registry = self.load_registry_at_commit_for_gc(&commit_id)?;
+            for (ns_name, entry) in registry {
+                self.collect_referenced_blobs_from_registry_entry(
+                    &ns_name,
+                    &entry,
+                    &mut referenced,
+                )?;
             }
         }
 
-        // 3. List every blob currently in storage.
+        // 4. List every blob currently in storage.
         let all_blobs = self
             .inner
             .tree
@@ -758,7 +756,7 @@ where
             .list_blobs()
             .map_err(|e| GitKvError::GitObjectError(format!("list_blobs: {e}")))?;
 
-        // 4. Delete orphans.
+        // 5. Delete orphans.
         let mut report = BlobGcReport {
             total: all_blobs.len(),
             referenced: referenced.len(),
@@ -775,6 +773,116 @@ where
             }
         }
         Ok(report)
+    }
+
+    fn collect_referenced_blobs_from_tree(
+        tree: &ProllyTree<N, S>,
+        referenced: &mut HashSet<ValueDigest<N>>,
+    ) {
+        for key in tree.collect_keys() {
+            let raw = tree.find(&key).and_then(|node| {
+                node.keys
+                    .iter()
+                    .position(|k| k == &key)
+                    .map(|i| node.values[i].clone())
+            });
+            if let Some(bytes) = raw {
+                if let Some((hash, _size)) =
+                    crate::storage::externalize::parse_envelope::<N>(&bytes)
+                {
+                    referenced.insert(hash);
+                }
+            }
+        }
+    }
+
+    fn collect_referenced_blobs_from_registry_entry(
+        &self,
+        ns_name: &str,
+        entry: &NamespaceEntry<N>,
+        referenced: &mut HashSet<ValueDigest<N>>,
+    ) -> Result<(), GitKvError> {
+        let Some(root_hash) = &entry.root_hash else {
+            return Ok(());
+        };
+        let mut config = entry.config.clone();
+        config.root_hash = Some(root_hash.clone());
+        let tree = ProllyTree::load_from_storage(self.inner.tree.storage.clone(), config)
+            .ok_or_else(|| {
+                GitKvError::GitObjectError(format!(
+                    "Failed to load namespace {ns_name} root {root_hash:x} during blob GC"
+                ))
+            })?;
+        Self::collect_referenced_blobs_from_tree(&tree, referenced);
+        Ok(())
+    }
+
+    fn reachable_commit_ids(&self) -> Result<HashSet<gix::ObjectId>, GitKvError> {
+        let mut seen = HashSet::new();
+        let mut queue = VecDeque::new();
+
+        if let Ok(head) = self.inner.metadata.head_commit_id() {
+            queue.push_back(head);
+        }
+
+        for branch in self.inner.metadata.list_branches()? {
+            queue.push_back(self.inner.metadata.branch_commit_id(&branch)?);
+        }
+
+        while let Some(commit_id) = queue.pop_front() {
+            if !seen.insert(commit_id) {
+                continue;
+            }
+            for parent in self.inner.metadata.commit_parents(&commit_id)? {
+                queue.push_back(parent);
+            }
+        }
+
+        Ok(seen)
+    }
+
+    fn load_registry_at_commit_for_gc(
+        &self,
+        commit_id: &gix::ObjectId,
+    ) -> Result<HashMap<String, NamespaceEntry<N>>, GitKvError> {
+        let registry_path = self.dataset_git_path(NAMESPACED_REGISTRY_FILENAME)?;
+        match self
+            .inner
+            .metadata
+            .read_file_at_commit(commit_id, &registry_path)
+        {
+            Ok(data) => serde_json::from_slice(&data).map_err(|e| {
+                GitKvError::GitObjectError(format!("Failed to parse registry at commit: {e}"))
+            }),
+            Err(_) => Ok(HashMap::new()),
+        }
+    }
+
+    fn dataset_git_path(&self, filename: &str) -> Result<String, GitKvError> {
+        let dataset_dir =
+            self.inner.dataset_dir.as_ref().ok_or_else(|| {
+                GitKvError::GitObjectError("Dataset directory not set".to_string())
+            })?;
+        let git_root = self
+            .inner
+            .metadata
+            .work_dir()
+            .or_else(|| VersionedKvStore::<N, S, M>::find_git_root(dataset_dir))
+            .ok_or_else(|| GitKvError::GitObjectError("Could not find git root".to_string()))?;
+        let relative = dataset_dir.strip_prefix(&git_root).map_err(|e| {
+            GitKvError::GitObjectError(format!("Dataset directory is not inside git root: {e}"))
+        })?;
+        let rel_str = relative
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+
+        if rel_str.is_empty() {
+            Ok(filename.to_string())
+        } else {
+            Ok(format!("{rel_str}/{filename}"))
+        }
     }
 
     // -- Commit -------------------------------------------------------------

--- a/src/storage/externalize.rs
+++ b/src/storage/externalize.rs
@@ -98,21 +98,20 @@ pub fn parse_envelope<const N: usize>(bytes: &[u8]) -> Option<(ValueDigest<N>, u
 /// Resolve a raw in-leaf byte slice to the user-visible value.
 ///
 /// If `raw` parses as an envelope **and** `storage` actually has a blob at
-/// the embedded hash, the blob bytes are returned. Otherwise the original
-/// `raw` bytes are returned unchanged.
+/// the embedded hash, the blob bytes are returned. If `raw` is not an envelope,
+/// the original bytes are returned unchanged.
 ///
-/// This **fall-through-on-miss** behaviour is what makes false-positive
-/// envelope parses (a real user value that coincidentally has the magic
-/// prefix and exact envelope length) recoverable: the hash won't point at
-/// any blob, so we degrade gracefully to inline.
-pub fn unwrap_value<const N: usize, S: NodeStorage<N>>(raw: &[u8], storage: &S) -> Vec<u8> {
+/// If `raw` is envelope-shaped but its blob is missing, returns `None` instead
+/// of the raw envelope bytes. This makes corruption visible to callers rather
+/// than silently returning the 44-byte envelope as user data.
+pub fn unwrap_value<const N: usize, S: NodeStorage<N>>(raw: &[u8], storage: &S) -> Option<Vec<u8>> {
     if let Some((hash, _original_size)) = parse_envelope::<N>(raw) {
         if let Some(blob) = storage.get_blob(&hash) {
-            return blob;
+            return Some(blob);
         }
-        // Envelope-shaped bytes but no matching blob → treat as inline.
+        return None;
     }
-    raw.to_vec()
+    Some(raw.to_vec())
 }
 
 #[cfg(test)]
@@ -176,26 +175,24 @@ mod tests {
         storage.insert_blob(hash.clone(), &payload).unwrap();
 
         let env = make_envelope::<32>(&hash, payload.len() as u64);
-        assert_eq!(unwrap_value::<32, _>(&env, &storage), payload);
+        assert_eq!(unwrap_value::<32, _>(&env, &storage), Some(payload));
     }
 
     #[test]
     fn unwrap_value_returns_raw_when_not_envelope() {
         let storage = InMemoryNodeStorage::<32>::new();
         let raw = b"a small inline value".to_vec();
-        assert_eq!(unwrap_value::<32, _>(&raw, &storage), raw);
+        assert_eq!(unwrap_value::<32, _>(&raw, &storage), Some(raw));
     }
 
     #[test]
-    fn unwrap_value_falls_back_when_envelope_hash_missing() {
-        // Envelope-shaped bytes but no blob behind the hash → graceful fallback
-        // returns the envelope bytes as-is. This is the false-positive recovery
-        // path that makes the magic-prefix scheme safe.
+    fn unwrap_value_returns_none_when_envelope_hash_missing() {
+        // Envelope-shaped bytes with no blob behind the hash represent a broken
+        // externalized value. Do not return the envelope as user data.
         let storage = InMemoryNodeStorage::<32>::new();
         let phantom_hash = ValueDigest::<32>::new(b"never_inserted");
         let env = make_envelope::<32>(&phantom_hash, 100);
         let got = unwrap_value::<32, _>(&env, &storage);
-        // Got back the envelope bytes (not crashed, not data loss).
-        assert_eq!(got, env);
+        assert_eq!(got, None);
     }
 }

--- a/tests/externalization.rs
+++ b/tests/externalization.rs
@@ -27,8 +27,31 @@ use common::setup_repo_and_dataset;
 use prollytree::digest::ValueDigest;
 use prollytree::git::versioned_store::FileNamespacedKvStore;
 use prollytree::storage::NodeStorage;
+use std::path::Path;
+use std::process::Command;
 
 const N: usize = 32;
+
+fn run_git(repo_path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo_path)
+        .output()
+        .expect("failed to run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn insert_orphan_blob(store: &FileNamespacedKvStore<N>, payload: &[u8]) -> ValueDigest<N> {
+    let hash = ValueDigest::<N>::new(payload);
+    let mut storage = store.inner_storage().clone();
+    storage.insert_blob(hash.clone(), payload).unwrap();
+    hash
+}
 
 #[test]
 fn small_value_stays_inline_when_threshold_set() {
@@ -298,9 +321,7 @@ fn gc_blobs_keeps_referenced_blobs() {
 }
 
 #[test]
-fn gc_blobs_removes_orphans_from_upsert() {
-    // Inserting v1 then v2 at the same key leaves v1's blob as an orphan.
-    // GC should remove it.
+fn gc_blobs_keeps_upsert_history_and_removes_true_orphan() {
     let (_temp, dataset) = setup_repo_and_dataset();
     let mut store = FileNamespacedKvStore::<N>::init(&dataset).unwrap();
     store.set_externalize_threshold(Some(64));
@@ -324,16 +345,20 @@ fn gc_blobs_removes_orphans_from_upsert() {
     // Pre-GC: both blobs are still around.
     assert!(store.inner_storage().get_blob(&h1).is_some());
     assert!(store.inner_storage().get_blob(&h2).is_some());
+    let orphan = vec![0xCC; 350];
+    let orphan_hash = insert_orphan_blob(&store, &orphan);
+    assert!(store.inner_storage().get_blob(&orphan_hash).is_some());
 
     let report = store.gc_blobs().unwrap();
-    assert_eq!(report.total, 2);
-    assert_eq!(report.referenced, 1);
+    assert_eq!(report.total, 3);
+    assert_eq!(report.referenced, 2);
     assert_eq!(report.removed, 1);
-    assert_eq!(report.remaining(), 1);
+    assert_eq!(report.remaining(), 2);
 
-    // The current value's blob survives; the orphan is gone.
-    assert!(store.inner_storage().get_blob(&h1).is_none());
+    // Both committed blobs survive; only the never-referenced blob is gone.
+    assert!(store.inner_storage().get_blob(&h1).is_some());
     assert!(store.inner_storage().get_blob(&h2).is_some());
+    assert!(store.inner_storage().get_blob(&orphan_hash).is_none());
 
     // The user still reads the latest value normally.
     let personal = store.namespace("personal");
@@ -341,8 +366,52 @@ fn gc_blobs_removes_orphans_from_upsert() {
 }
 
 #[test]
-fn gc_blobs_removes_orphans_from_delete() {
-    // Deleting a key doesn't eagerly delete the referenced blob; gc_blobs does.
+fn gc_blobs_keeps_blobs_referenced_by_historical_commits() {
+    let (temp, dataset) = setup_repo_and_dataset();
+    let mut store = FileNamespacedKvStore::<N>::init(&dataset).unwrap();
+    store.set_externalize_threshold(Some(64));
+
+    let old_value = vec![0xA1; 256];
+    let new_value = vec![0xB2; 300];
+    let old_hash = ValueDigest::<N>::new(&old_value);
+    let new_hash = ValueDigest::<N>::new(&new_value);
+
+    {
+        let mut personal = store.namespace("personal");
+        personal.insert(b"k".to_vec(), old_value.clone()).unwrap();
+    }
+    store.commit("old externalized value").unwrap();
+    store.create_branch("old-value").unwrap();
+    drop(store);
+    run_git(temp.path(), &["checkout", "main"]);
+
+    let mut store = FileNamespacedKvStore::<N>::open(&dataset).unwrap();
+    store.set_externalize_threshold(Some(64));
+    {
+        let mut personal = store.namespace("personal");
+        personal.insert(b"k".to_vec(), new_value.clone()).unwrap();
+    }
+    store.commit("new externalized value").unwrap();
+
+    assert!(store.inner_storage().get_blob(&old_hash).is_some());
+    assert!(store.inner_storage().get_blob(&new_hash).is_some());
+
+    let report = store.gc_blobs().unwrap();
+    assert_eq!(report.total, 2);
+    assert_eq!(report.referenced, 2);
+    assert_eq!(report.removed, 0);
+    assert!(store.inner_storage().get_blob(&old_hash).is_some());
+    assert!(store.inner_storage().get_blob(&new_hash).is_some());
+
+    drop(store);
+    run_git(temp.path(), &["checkout", "old-value"]);
+    let mut old_store = FileNamespacedKvStore::<N>::open(&dataset).unwrap();
+    let personal = old_store.namespace("personal");
+    assert_eq!(personal.get(b"k"), Some(old_value));
+}
+
+#[test]
+fn gc_blobs_keeps_deleted_history_and_removes_true_orphan() {
     let (_temp, dataset) = setup_repo_and_dataset();
     let mut store = FileNamespacedKvStore::<N>::init(&dataset).unwrap();
     store.set_externalize_threshold(Some(64));
@@ -362,16 +431,18 @@ fn gc_blobs_removes_orphans_from_delete() {
     }
     store.commit("delete").unwrap();
 
-    // Blob still around after delete commit — that's PR 0b behaviour.
+    // Blob still around after delete commit and remains referenced by history.
     assert!(store.inner_storage().get_blob(&hash).is_some());
+    let orphan = vec![0xDD; 350];
+    let orphan_hash = insert_orphan_blob(&store, &orphan);
 
     let report = store.gc_blobs().unwrap();
-    assert_eq!(report.total, 1);
-    assert_eq!(report.referenced, 0);
+    assert_eq!(report.total, 2);
+    assert_eq!(report.referenced, 1);
     assert_eq!(report.removed, 1);
 
-    // Blob is gone.
-    assert!(store.inner_storage().get_blob(&hash).is_none());
+    assert!(store.inner_storage().get_blob(&hash).is_some());
+    assert!(store.inner_storage().get_blob(&orphan_hash).is_none());
 }
 
 #[test]
@@ -436,13 +507,17 @@ fn gc_blobs_idempotent() {
     }
     store.commit("v2").unwrap();
 
+    let orphan = vec![0xCC; 350];
+    let orphan_hash = insert_orphan_blob(&store, &orphan);
+    assert!(store.inner_storage().get_blob(&orphan_hash).is_some());
+
     let first = store.gc_blobs().unwrap();
     assert_eq!(first.removed, 1);
 
     // Second GC has nothing to do.
     let second = store.gc_blobs().unwrap();
-    assert_eq!(second.total, 1);
-    assert_eq!(second.referenced, 1);
+    assert_eq!(second.total, 2);
+    assert_eq!(second.referenced, 2);
     assert_eq!(second.removed, 0);
 }
 


### PR DESCRIPTION
# GC Preserves Historical Externalized Blobs

## Bug

`NamespacedKvStore::gc_blobs` treated only the current namespace roots as live references. Externalized values reachable only from older commits, older branches, or deleted-key history were counted as orphan blobs and removed.

## Impact

The Git-backed store promises versioned key-value history. After GC, checking out an older commit or branch could leave its tree envelope pointing at a missing blob. That turns a storage maintenance operation into data loss for historical reads.

## Root Cause

Blob liveness was computed from the current in-memory namespace state instead of walking the committed namespace registry and historical namespace roots. `unwrap_value` also could not distinguish a real inline value from an externalization envelope whose blob had been deleted, so missing blobs were easy to miss until a historical read returned the wrong shape.

## Regression Proof

The regression tests cover three live-history cases:

- `gc_blobs_keeps_upsert_history_and_removes_true_orphan`
- `gc_blobs_keeps_blobs_referenced_by_historical_commits`
- `gc_blobs_keeps_deleted_history_and_removes_true_orphan`

On `main`, those cases expose that GC preserves only the latest externalized value and can remove blobs still needed by history. The tests also include a true never-referenced blob so the fix still proves GC deletes actual garbage.

## Fix

The branch makes GC history-aware by collecting blob references from the current namespace state and from committed historical namespace roots. Missing externalized blobs are surfaced as absent values rather than silently returning envelope bytes.

This keeps the cleanup boundary tight: blobs are deleted only when no reachable current or historical tree references them.

## Verification

Run from a temporary target directory, not the project working directory:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-target cargo test --features "git sql" gc_blobs
CARGO_TARGET_DIR=/tmp/prollytree-target cargo test --features "git sql" --test externalization
```
