### PR TITLE
fix(digest): support generic digest widths

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -55,18 +55,28 @@ impl<const N: usize> ValueDigest<N> {
     ///
     /// A `ValueDigest` instance containing the computed hash.
     pub fn new(data: &[u8]) -> Self {
-        // Ensure N is not larger than 32 to prevent out-of-bounds errors
-        assert!(
-            N <= 32,
-            "N must be less than or equal to 32 due to SHA-256 output size"
-        );
-
         let mut hasher = Sha256::new();
         hasher.update(data);
         let result = hasher.finalize();
 
         let mut hash = [0u8; N];
-        hash.copy_from_slice(&result[..N]);
+        let first_len = N.min(32);
+        hash[..first_len].copy_from_slice(&result[..first_len]);
+
+        let mut filled = first_len;
+        let mut counter = 0u64;
+        while filled < N {
+            let mut extender = Sha256::new();
+            extender.update(b"prollytree-value-digest-extension-v1");
+            extender.update(data);
+            extender.update(counter.to_le_bytes());
+            let block = extender.finalize();
+            let take = (N - filled).min(block.len());
+            hash[filled..filled + take].copy_from_slice(&block[..take]);
+            filled += take;
+            counter += 1;
+        }
+
         ValueDigest(hash)
     }
 

--- a/tests/generic_digest_size.rs
+++ b/tests/generic_digest_size.rs
@@ -1,0 +1,134 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use prollytree::config::TreeConfig;
+use prollytree::digest::ValueDigest;
+use prollytree::storage::{InMemoryNodeStorage, NodeStorage};
+use prollytree::tree::{ProllyTree, Tree};
+use sha2::{Digest, Sha256};
+
+fn get<const N: usize, S: NodeStorage<N>>(tree: &ProllyTree<N, S>, key: &[u8]) -> Option<Vec<u8>> {
+    tree.find(key).and_then(|node| {
+        node.keys
+            .iter()
+            .zip(node.values.iter())
+            .find(|(stored_key, _)| stored_key.as_slice() == key)
+            .map(|(_, value)| value.clone())
+    })
+}
+
+fn splitty_config<const N: usize>() -> TreeConfig<N> {
+    TreeConfig {
+        base: 257,
+        modulus: 1_000_000_007,
+        min_chunk_size: 2,
+        max_chunk_size: 64,
+        pattern: 0b1111,
+        ..TreeConfig::<N>::default()
+    }
+}
+
+fn roundtrip<const N: usize>() {
+    let mut tree = ProllyTree::new(InMemoryNodeStorage::<N>::default(), splitty_config::<N>());
+
+    for i in 0..256u32 {
+        tree.insert(
+            format!("key-{i:08}").into_bytes(),
+            format!("value-{i}").into_bytes(),
+        );
+    }
+
+    let root = tree.get_root_hash().expect("tree must have a root hash");
+    assert_eq!(root.as_bytes().len(), N);
+
+    for i in 0..256u32 {
+        let key = format!("key-{i:08}").into_bytes();
+        assert_eq!(get(&tree, &key), Some(format!("value-{i}").into_bytes()));
+    }
+
+    let update_key = b"key-00000042".to_vec();
+    assert!(tree.update(update_key.clone(), b"UPDATED".to_vec()));
+    assert_eq!(get(&tree, &update_key), Some(b"UPDATED".to_vec()));
+
+    let delete_key = b"key-00000100".to_vec();
+    assert!(tree.delete(&delete_key));
+    assert_eq!(get(&tree, &delete_key), None);
+
+    tree.persist_root();
+    let reloaded = ProllyTree::load_from_storage(tree.storage.clone(), tree.config.clone())
+        .expect("reload from storage must succeed");
+    assert_eq!(get(&reloaded, &update_key), Some(b"UPDATED".to_vec()));
+    assert_eq!(get(&reloaded, &delete_key), None);
+}
+
+fn history_independent<const N: usize>() {
+    let ascending: Vec<u32> = (0..256).collect();
+    let mut shuffled: Vec<u32> = (0..256).step_by(2).chain((1..256).step_by(2)).collect();
+    shuffled.rotate_left(37);
+
+    let build = |order: &[u32]| -> ValueDigest<N> {
+        let mut tree = ProllyTree::new(InMemoryNodeStorage::<N>::default(), splitty_config::<N>());
+        for &i in order {
+            tree.insert(
+                format!("key-{i:08}").into_bytes(),
+                format!("value-{i}").into_bytes(),
+            );
+        }
+        tree.get_root_hash().expect("root hash")
+    };
+
+    assert_eq!(build(&ascending), build(&shuffled));
+}
+
+#[test]
+fn n32_digest_is_unchanged_sha256() {
+    let data = b"prollytree canonical hash pin";
+    let expected = Sha256::digest(data);
+
+    assert_eq!(ValueDigest::<32>::new(data).as_bytes(), &expected[..]);
+}
+
+#[test]
+fn wider_digest_extends_narrower_prefix() {
+    let data = b"some content to hash";
+    let d32 = ValueDigest::<32>::new(data);
+    let d64 = ValueDigest::<64>::new(data);
+
+    assert_eq!(&d64.as_bytes()[..32], d32.as_bytes());
+}
+
+#[test]
+fn roundtrip_n16() {
+    roundtrip::<16>();
+}
+
+#[test]
+fn roundtrip_n32() {
+    roundtrip::<32>();
+}
+
+#[test]
+fn roundtrip_n48() {
+    roundtrip::<48>();
+}
+
+#[test]
+fn roundtrip_n64() {
+    roundtrip::<64>();
+}
+
+#[test]
+fn history_independence_n64() {
+    history_independent::<64>();
+}


### PR DESCRIPTION
# Generic Digest Sizes Do Not Panic

## Bug

`ValueDigest::<N>::new` asserted `N <= 32` and then copied from a 32-byte SHA-256 output. The public types are generic over digest width, but choosing `N = 48` or `N = 64` panicked immediately.

## Impact

Digest width looked configurable in the API but was not usable beyond 32 bytes. Wider Merkle digests could not be tested or adopted, and callers could trigger a runtime panic from an otherwise valid type parameter.

## Root Cause

The implementation coupled the generic digest type directly to the fixed output width of SHA-256. The copy was protected by an assertion instead of providing deterministic bytes for widths larger than the base hash.

## Regression Proof

`tests/generic_digest_size.rs` exercises `N = 16`, `32`, `48`, and `64` through insert, update, delete, persist, reload, and history-independence checks. On `main`, the first `N = 48` or `N = 64` digest construction panics with the old width assertion.

The tests also pin `N = 32` to the existing SHA-256 bytes so this fix cannot silently rewrite persisted 32-byte roots.

## Fix

The fork-local PR branch preserves the current SHA-256 contract for `N <= 32`. For wider digests, it keeps the first 32 bytes byte-identical to SHA-256 and fills the remaining bytes from deterministic domain-separated SHA-256 extension blocks.

That makes widening `N` additive: a 64-byte digest extends the 32-byte digest prefix instead of changing it.

## Verification

Run from a temporary target directory:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-target cargo test --test generic_digest_size
CARGO_TARGET_DIR=/tmp/prollytree-target cargo test --features "git sql"
```
