### PR TITLE
fix(git): error on missing historical mappings

### DIFF
--- a/src/git/versioned_store/backends.rs
+++ b/src/git/versioned_store/backends.rs
@@ -726,19 +726,32 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
 
         let config_result = self.metadata.read_file_at_commit(commit_id, &config_path);
         let mapping_result = self.metadata.read_file_at_commit(commit_id, &mapping_path);
+        let (config_data, mapping_data) = match (config_result, mapping_result) {
+            (Ok(config_data), Ok(mapping_data)) => (config_data, mapping_data),
+            (Err(_), Err(_)) => {
+                // Older repositories can have non-prolly commits before the
+                // dataset exists. With neither file present, the committed
+                // prolly state is genuinely empty.
+                return Ok(HashMap::new());
+            }
+            (Ok(_), Err(e)) => {
+                return Err(GitKvError::GitObjectError(format!(
+                    "Historical commit {commit_id} has {config_path} but is missing {mapping_path}: {e}"
+                )));
+            }
+            (Err(e), Ok(_)) => {
+                return Err(GitKvError::GitObjectError(format!(
+                    "Historical commit {commit_id} has {mapping_path} but is missing {config_path}: {e}"
+                )));
+            }
+        };
 
-        // If files are not found, this might be an initial empty commit, return empty
-        if config_result.is_err() || mapping_result.is_err() {
-            return Ok(HashMap::new());
-        }
-
-        let config_data = config_result?;
         let config: TreeConfig<N> = serde_json::from_slice(&config_data).map_err(|e| {
             GitKvError::GitObjectError(format!("Failed to deserialize config: {e}"))
         })?;
+        let root_hash = config.root_hash.clone();
 
         // Load the hash mappings from the tree as string format and parse
-        let mapping_data = mapping_result?;
         let mapping_str = String::from_utf8(mapping_data)
             .map_err(|e| GitKvError::GitObjectError(format!("Invalid UTF-8 in mappings: {e}")))?;
 
@@ -792,6 +805,11 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
 
         // For Git storage, reconstruct the tree from hash mappings
         if hash_mappings.is_empty() {
+            if let Some(root_hash) = root_hash {
+                return Err(GitKvError::GitObjectError(format!(
+                    "Historical commit {commit_id} has root {root_hash:x} but {mapping_path} contains no hash mappings"
+                )));
+            }
             return Ok(HashMap::new());
         }
 
@@ -806,6 +824,14 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         let tree = ProllyTree::load_from_storage(temp_storage, config).ok_or_else(|| {
             GitKvError::GitObjectError("Failed to load tree from storage".to_string())
         })?;
+        if let Some(root_hash) = root_hash {
+            validate_persistent_tree_nodes(
+                &root_hash,
+                &tree.root,
+                &tree.storage,
+                "Git historical",
+            )?;
+        }
 
         // Collect all key-value pairs
         let mut result_key_values = HashMap::new();

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -215,6 +215,72 @@ mod proof_tests {
             Some(&b"value3".to_vec())
         );
     }
+
+    #[test]
+    fn get_keys_at_ref_errors_when_committed_hash_mappings_are_missing() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let repo_path = temp_dir.path().to_str().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to initialize git repo");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user name");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo_path)
+            .output()
+            .expect("Failed to set git user email");
+
+        let dataset_path = temp_dir.path().join("dataset");
+        std::fs::create_dir(&dataset_path).expect("Failed to create dataset directory");
+        let _cwd_guard = CwdGuard::set(&dataset_path);
+        let mut store =
+            GitVersionedKvStore::<32>::init(&dataset_path).expect("Failed to initialize store");
+
+        store
+            .insert(b"key1".to_vec(), b"value1".to_vec())
+            .expect("Failed to insert key1");
+        let good_commit = store.commit("Add key1").expect("Failed to commit");
+        let good_keys = store
+            .get_keys_at_ref(&good_commit.to_hex().to_string())
+            .expect("good commit should be readable");
+        assert_eq!(good_keys.get(&b"key1".to_vec()), Some(&b"value1".to_vec()));
+
+        let rm_output = std::process::Command::new("git")
+            .args(["rm", "dataset/prolly_hash_mappings"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git rm failed to run");
+        assert!(
+            rm_output.status.success(),
+            "git rm failed: {}",
+            String::from_utf8_lossy(&rm_output.stderr)
+        );
+        let commit_output = std::process::Command::new("git")
+            .args(["commit", "-m", "Remove hash mappings"])
+            .current_dir(repo_path)
+            .output()
+            .expect("git commit failed to run");
+        assert!(
+            commit_output.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit_output.stderr)
+        );
+
+        let err = store
+            .get_keys_at_ref("HEAD")
+            .expect_err("missing committed mappings must not look like an empty store");
+        assert!(
+            err.to_string().contains("prolly_hash_mappings"),
+            "unexpected error: {err}"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Git Historical Reads Error On Missing Hash Mappings

## Bug

`GitVersionedKvStore::collect_keys_at_commit` returned an empty key map whenever
either the committed tree config or the committed `prolly_hash_mappings` file was
missing. A corrupt commit that still had a saved tree root but no hash mappings
therefore looked identical to an empty historical state.

## Impact

Historical reads could falsely report that a commit contained no keys. APIs such
as `get_keys_at_ref`, `diff`, and key-history scans depend on accurate committed
state; silently returning `{}` hides storage corruption and can make later
history or merge decisions operate on incomplete data.

## Fix

The Git historical read path now allows the legacy empty case only when both the
config and mapping files are absent. If exactly one file is present, it returns a
`GitObjectError` that names the missing file. If a config has a tree root but the
mapping file parses to no hash mappings, it also returns an error instead of an
empty key set. After reconstructing the temporary historical Git storage, the
loaded tree is validated so missing descendant mappings cannot produce a partial
key set.

## Regression Proof

The branch adds
`get_keys_at_ref_errors_when_committed_hash_mappings_are_missing` in
`src/git/versioned_store/tests.rs`. The test creates a normal Git-backed dataset,
commits a key, verifies the good commit is readable, then creates a deliberately
corrupt commit by removing `dataset/prolly_hash_mappings` while leaving the tree
config in place.

Against `main`, `get_keys_at_ref("HEAD")` returned `{}` for the corrupt commit.
The fixed branch returns an error mentioning `prolly_hash_mappings`.

## Verification

Run on `fix/git-historical-missing-mapping-error`:

- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-git-historical-mapping-target /opt/homebrew/bin/cargo test --lib --features git get_keys_at_ref_errors_when_committed_hash_mappings_are_missing -- --nocapture`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-git-historical-mapping-target /opt/homebrew/bin/cargo test --lib --features git git::versioned_store::tests -- --nocapture`
- `/opt/homebrew/bin/cargo fmt --all -- --check`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-git-historical-mapping-target /opt/homebrew/bin/cargo build --all`
- `timeout 240 zsh -lc 'CARGO_TARGET_DIR=/tmp/prollytree-git-historical-mapping-clippy-target /opt/homebrew/bin/cargo clippy --all -q; rc=$?; echo CLIPPY_STATUS:$rc; exit $rc'`
