### PR TITLE
fix(storage): preserve git storage configs on clone

### DIFF
--- a/src/storage/git.rs
+++ b/src/storage/git.rs
@@ -47,7 +47,7 @@ impl<const N: usize> Clone for GitNodeStorage<N> {
         let cloned = Self {
             _repository: self._repository.clone(),
             cache: Mutex::new(LruCache::new(DEFAULT_CACHE_SIZE)),
-            configs: Mutex::new(HashMap::new()),
+            configs: Mutex::new(self.configs.lock().clone()),
             hash_to_object_id: Mutex::new(HashMap::new()),
             dataset_dir: self.dataset_dir.clone(),
         };
@@ -437,5 +437,32 @@ mod tests {
         // Get from cache
         let cached = storage.get_node_by_hash(&hash1);
         assert!(cached.is_some());
+    }
+
+    #[test]
+    fn clone_preserves_memory_only_tree_config() {
+        let (temp_dir, repo) = create_test_repo();
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir_all(&dataset_dir).unwrap();
+        let storage = GitNodeStorage::<32>::new(repo, dataset_dir.clone()).unwrap();
+        let config = br#"{"root_hash":null}"#;
+
+        storage.save_config("tree_config", config);
+        assert_eq!(
+            storage.get_config("tree_config").as_deref(),
+            Some(&config[..])
+        );
+        assert!(
+            !dataset_dir.join("prolly_config_tree_config").exists(),
+            "tree_config is intentionally memory-only for GitNodeStorage"
+        );
+
+        let cloned = storage.clone();
+
+        assert_eq!(
+            cloned.get_config("tree_config").as_deref(),
+            Some(&config[..]),
+            "cloning GitNodeStorage must preserve memory-only tree_config"
+        );
     }
 }


### PR DESCRIPTION
# Git Storage Clone Preserves Memory Configs

## Bug

`GitNodeStorage::clone` created a fresh empty config map instead of carrying over
the source storage instance's in-memory configs. That lost `tree_config`, which
`GitNodeStorage::save_config` intentionally keeps memory-only to avoid writing a
second compact config file beside the canonical pretty-printed Git config.

## Impact

Any cloned storage handle could read nodes and mappings from the same dataset
but fail to read the tree configuration that the original handle had already
saved. Code paths that clone storage before reading `tree_config` could behave
as if the tree had no saved config even though the active storage instance did.

## Fix

The manual `Clone` implementation now snapshots the existing config map into the
cloned storage. Cache contents still start empty, and hash mappings still reload
from disk, so the change is limited to state that is intentionally memory-only.

## Regression Proof

The branch adds `clone_preserves_memory_only_tree_config` in `src/storage/git.rs`.
The test stores a `tree_config`, verifies that no
`prolly_config_tree_config` file was written, clones the storage, and asserts
that the cloned storage can read the same config bytes.

Against the pre-fix implementation, the cloned storage returned `None` for
`tree_config`. The fixed branch preserves the memory-only config across clone.

## Verification

Verified on `fix/git-storage-clone-configs` during the bug-fix campaign:

- `CARGO_TARGET_DIR=/tmp/prollytree-git-storage-clone-target cargo test --features git clone_preserves_memory_only_tree_config -- --nocapture`
