### PR TITLE
fix(storage): avoid git sync temp path collisions

### DIFF
--- a/src/storage/git.rs
+++ b/src/storage/git.rs
@@ -19,12 +19,25 @@ use gix::prelude::*;
 use lru::LruCache;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 const DEFAULT_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).unwrap();
+static SYNC_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 use parking_lot::Mutex;
 use std::sync::Arc;
 
 use super::{NodeStorage, StorageError};
+
+fn sync_temp_path(dataset_dir: &Path, nanos: u64) -> std::path::PathBuf {
+    let counter = SYNC_TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    dataset_dir.join(format!(
+        ".prolly_hash_mappings.{}.{}.{}",
+        std::process::id(),
+        nanos,
+        counter
+    ))
+}
 
 /// Git-backed storage for ProllyTree nodes
 ///
@@ -308,11 +321,7 @@ impl<const N: usize> NodeStorage<N> for GitNodeStorage<N> {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos() as u64)
             .unwrap_or(0);
-        let tmp = self.dataset_dir.join(format!(
-            ".prolly_hash_mappings.{}.{}",
-            std::process::id(),
-            nanos
-        ));
+        let tmp = sync_temp_path(&self.dataset_dir, nanos);
         {
             use std::io::Write as _;
             let mut f = std::fs::File::create(&tmp).map_err(StorageError::Io)?;
@@ -437,5 +446,17 @@ mod tests {
         // Get from cache
         let cached = storage.get_node_by_hash(&hash1);
         assert!(cached.is_some());
+    }
+
+    #[test]
+    fn sync_temp_path_uses_counter_for_same_timestamp() {
+        let temp_dir = TempDir::new().unwrap();
+        let first = sync_temp_path(temp_dir.path(), 123);
+        let second = sync_temp_path(temp_dir.path(), 123);
+
+        assert_ne!(
+            first, second,
+            "same-process sync temp paths must not collide for the same timestamp"
+        );
     }
 }


### PR DESCRIPTION
# Git Sync Temporary Path Collision

## Bug

`GitNodeStorage::sync` wrote the hash-mapping file through a temporary path based
only on process id and the current timestamp in nanoseconds. Two sync calls in
the same process with the same timestamp could choose the same temporary path and
interfere with each other.

## Impact

The mapping file links value digests to Git object IDs. A collision in the sync
temporary path could corrupt or lose an in-flight mapping write, especially under
concurrent calls or low-resolution clock behavior. That makes later node lookup
less reliable even when the underlying Git blobs exist.

## Fix

The sync temporary path now includes a process-local atomic counter in addition
to process id and timestamp. This matches the uniqueness discipline already used
elsewhere in the Git storage backend. The final mapping file path and on-disk
format remain unchanged.

## Regression Proof

The branch adds `sync_temp_path_uses_counter_for_same_timestamp` in
`src/storage/git.rs`. The test calls the temp-path generator twice with the same
timestamp and asserts the generated paths are distinct.

Against the pre-fix implementation, same-process same-timestamp calls produced
the same path. The fixed branch guarantees unique temporary paths for that case.

## Verification

Verified on `fix/git-sync-temp-collision` during the bug-fix campaign:

- `cargo test --lib sync_temp_path_uses_counter_for_same_timestamp`
- `cargo test --features "git sql proximity"`
- `cargo build --all`
- `cargo clippy --all`
- `cargo fmt --all -- --check`
