### PR TITLE
fix(git): error on missing historical root nodes

### DIFF
--- a/src/git/versioned_store/history.rs
+++ b/src/git/versioned_store/history.rs
@@ -75,22 +75,22 @@ where
     ) -> Result<TreeConfig<N>, GitKvError> {
         let config_path = self.get_config_file_path_relative_to_git_root()?;
 
-        match self.metadata.read_file_at_commit(commit_id, &config_path) {
-            Ok(config_data) => {
-                let tree_config: TreeConfig<N> =
-                    serde_json::from_slice(&config_data).map_err(|e| {
-                        GitKvError::GitObjectError(format!("Failed to parse tree config: {e}"))
-                    })?;
-                Ok(tree_config)
-            }
-            Err(_) => {
-                eprintln!(
-                    "Warning: {} not found in commit {commit_id}, using default config",
+        let config_data = self
+            .metadata
+            .read_file_at_commit(commit_id, &config_path)
+            .map_err(|e| {
+                GitKvError::GitObjectError(format!(
+                    "Failed to read {} from commit {commit_id}: {e}",
                     self.config_filename
-                );
-                Ok(TreeConfig::default())
-            }
-        }
+                ))
+            })?;
+
+        serde_json::from_slice(&config_data).map_err(|e| {
+            GitKvError::GitObjectError(format!(
+                "Failed to parse {} from commit {commit_id}: {e}",
+                self.config_filename
+            ))
+        })
     }
 
     /// Collect all key-value pairs from storage using a tree config (with root hash)
@@ -100,26 +100,20 @@ where
         tree_config: &TreeConfig<N>,
     ) -> Result<HashMap<Vec<u8>, Vec<u8>>, GitKvError> {
         // Get the root hash from the config
-        let root_hash = match tree_config.root_hash.as_ref() {
-            Some(hash) => hash,
-            None => {
-                // If no root hash in config, return empty result
-                // This can happen for initial commits or when config wasn't properly saved
-                eprintln!("Warning: No root hash in tree config, returning empty key set");
-                return Ok(HashMap::new());
-            }
-        };
+        let root_hash = tree_config.root_hash.as_ref().ok_or_else(|| {
+            GitKvError::GitObjectError("Historical tree config is missing a root hash".to_string())
+        })?;
 
         // Reconstruct the tree from storage using the root hash
-        let root_node = match self.tree.storage.get_node_by_hash(root_hash) {
-            Some(node) => node,
-            None => {
-                // Root node not found in storage, return empty result
-                // This can happen if the historical state is not available in current storage
-                eprintln!("Warning: Root node not found in storage for hash {root_hash:?}, returning empty key set");
-                return Ok(HashMap::new());
-            }
-        };
+        let root_node = self
+            .tree
+            .storage
+            .get_node_by_hash(root_hash)
+            .ok_or_else(|| {
+                GitKvError::GitObjectError(format!(
+                    "Root node not found in storage for historical root hash {root_hash:x}"
+                ))
+            })?;
 
         // Traverse the tree to collect all keys
         let mut result = HashMap::new();
@@ -140,18 +134,26 @@ where
                 result.insert(key.clone(), value.clone());
             }
         } else {
-            // Internal node: recursively visit children
+            // Internal node: recursively visit children. Missing children mean
+            // the historical tree is corrupt; returning partial or empty data
+            // would make corruption indistinguishable from a valid commit.
             for value in &node.values {
-                // Value contains the hash of the child node
-                if value.len() == N {
-                    let mut hash_array = [0u8; N];
-                    hash_array.copy_from_slice(value);
-                    let child_hash = ValueDigest(hash_array);
-
-                    if let Some(child_node) = self.tree.storage.get_node_by_hash(&child_hash) {
-                        self.collect_keys_recursive(&child_node, result)?;
-                    }
+                if value.len() != N {
+                    return Err(GitKvError::GitObjectError(format!(
+                        "Invalid child hash length {} in historical tree node; expected {N}",
+                        value.len()
+                    )));
                 }
+
+                let mut hash_array = [0u8; N];
+                hash_array.copy_from_slice(value);
+                let child_hash = ValueDigest(hash_array);
+                let Some(child_node) = self.tree.storage.get_node_by_hash(&child_hash) else {
+                    return Err(GitKvError::GitObjectError(format!(
+                        "Child node not found in storage for historical hash {child_hash:x}"
+                    )));
+                };
+                self.collect_keys_recursive(&child_node, result)?;
             }
         }
         Ok(())
@@ -176,18 +178,12 @@ where
         let mut previous_value: Option<Vec<u8>> = None; // None = key not present, Some(val) = key present with value
 
         for commit in commit_history {
-            // Get the key value at this commit by reconstructing tree state
-            let current_value = {
-                if let Ok(tree_config) = self.read_tree_config_from_commit(&commit.id) {
-                    if let Ok(keys_at_commit) = self.collect_keys_from_config(&tree_config) {
-                        keys_at_commit.get(key).cloned()
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            };
+            // Get the key value at this commit by reconstructing tree state.
+            // Reconstruction errors are surfaced because otherwise corrupted
+            // historical storage is reported as a legitimate key deletion.
+            let tree_config = self.read_tree_config_from_commit(&commit.id)?;
+            let keys_at_commit = self.collect_keys_from_config(&tree_config)?;
+            let current_value = keys_at_commit.get(key).cloned();
 
             // Check if the value changed from the previous commit
             let value_changed = previous_value != current_value;

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -226,6 +226,7 @@ mod tests {
         FileVersionedKvStore, GitVersionedKvStore, HistoricalAccess, HistoricalCommitAccess,
         InMemoryVersionedKvStore, ThreadSafeGitVersionedKvStore,
     };
+    use crate::tree::Tree;
     use tempfile::TempDir;
 
     /// RAII guard that holds the global CWD mutex and restores the working
@@ -811,6 +812,38 @@ mod tests {
             let key1_commits = store.get_commits(b"key1").unwrap();
             assert!(!key1_commits.is_empty());
         }
+    }
+
+    #[test]
+    fn file_history_reports_missing_root_node() {
+        let temp_dir = TempDir::new().unwrap();
+        gix::init(temp_dir.path()).unwrap();
+
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        let mut store = FileVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+        store.insert(b"key1".to_vec(), b"value1".to_vec()).unwrap();
+        store.commit("Add data").unwrap();
+
+        let root_hash = store.tree.get_root_hash().expect("root hash after commit");
+        let root_path = temp_dir
+            .path()
+            .join(".git")
+            .join("prolly")
+            .join("nodes")
+            .join("files")
+            .join(format!("{root_hash:x}"));
+        std::fs::remove_file(root_path).unwrap();
+
+        let err = store
+            .get_keys_at_ref("HEAD")
+            .expect_err("missing historical root node must be reported as corruption");
+        assert!(
+            err.to_string().contains("Root node not found"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Historical Reads Error On Missing Root Nodes

## Bug

Generic historical reads for non-Git node storage returned an empty key map when
the committed tree config pointed at a root node that was no longer available in
node storage. The same reconstruction path also treated missing configs,
missing child nodes, and malformed child hash references as absent data instead
of historical tree corruption.

## Impact

`FileVersionedKvStore` and other generic historical backends could report a
corrupt historical commit as `{}`. Public APIs built on `get_keys_at_ref`,
including `diff` and key-history scans, could then treat lost storage as a real
empty commit or legitimate key deletion.

## Fix

The generic historical reconstruction path now returns `GitObjectError` when a
commit cannot provide a readable tree config, a config has no root hash, the
root node is missing, or any internal child reference is malformed or missing.
`get_commits_for_key_generic` now propagates reconstruction errors instead of
converting them into `None` for the key.

## Regression Proof

The branch adds `file_history_reports_missing_root_node` in
`src/git/versioned_store/tests.rs`. The test creates a File-backed versioned
store, commits one key, deletes the persisted root node from
`.git/prolly/nodes/files/`, then calls `get_keys_at_ref("HEAD")`.

Against the pre-fix implementation, the call printed a warning and returned
`Ok({})`. The fixed branch returns an error mentioning the missing root node.

## Verification

Run on `fix/historical-missing-root-node`:

- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-history-missing-root-target /opt/homebrew/bin/cargo test --lib --features git file_history_reports_missing_root_node -- --nocapture`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-history-missing-root-target /opt/homebrew/bin/cargo test --lib --features git git::versioned_store::tests -- --nocapture`
- `/opt/homebrew/bin/cargo fmt --all -- --check`
- `RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc" CARGO_TARGET_DIR=/tmp/prollytree-history-missing-root-target /opt/homebrew/bin/cargo build --all`
- `CARGO_TARGET_DIR=/tmp/prollytree-history-missing-root-clippy-target /opt/homebrew/bin/cargo clippy --all`
