### PR TITLE
fix: reject mismatched insert batches

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -357,6 +357,11 @@ impl<const N: usize, S: NodeStorage<N>> Tree<N, S> for ProllyTree<N, S> {
     }
 
     fn insert_batch(&mut self, keys: &[Vec<u8>], values: &[Vec<u8>]) {
+        assert_eq!(
+            keys.len(),
+            values.len(),
+            "insert_batch requires the same number of keys and values"
+        );
         let batch = keys.iter().cloned().zip(values.iter().cloned().map(Some));
         self.apply_changes(batch);
     }
@@ -1334,6 +1339,18 @@ mod tests {
         assert!(tree.find(b"key2").is_some());
         assert!(tree.find(b"key3").is_some());
         assert!(tree.find(b"key4").is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "insert_batch requires the same number of keys and values")]
+    fn test_insert_batch_rejects_length_mismatch() {
+        let storage = InMemoryNodeStorage::<32>::default();
+        let mut tree = ProllyTree::new(storage, TreeConfig::default());
+
+        let keys = vec![b"key1".to_vec(), b"key2".to_vec()];
+        let values = vec![b"value1".to_vec()];
+
+        tree.insert_batch(&keys, &values);
     }
 
     #[test]


### PR DESCRIPTION
# Bug #44: `insert_batch` Silently Dropped Mismatched Keys or Values

## Problem

`ProllyTree::insert_batch` accepted separate `keys` and `values` slices, then
combined them with `zip`. If the caller passed different lengths, Rust's `zip`
silently stopped at the shorter slice. Extra keys or values were ignored with no
signal to the caller.

That is a data-loss footgun: a caller can believe a batch was fully inserted
while trailing entries were never written.

## Fix

`insert_batch` now asserts that the key and value slices have the same length
before building the mutation batch. The method has no `Result` return type, so a
panic is the least surprising way to reject programmer-error input without
silently dropping data.

## Regression Proof

The regression test verifies that a mismatched batch panics with a targeted
message. Existing batch tests still verify normal equal-length insertion.

## Verification

- `cargo test --features "git sql" tree::tests::test_insert_batch_rejects_length_mismatch -- --nocapture`
- `cargo test --features "git sql" tree::tests::test_insert_batch_and_find -- --nocapture`
