### PR TITLE
fix(merge): conflict on delete modify collisions

### DIFF
--- a/src/git/versioned_store/backends.rs
+++ b/src/git/versioned_store/backends.rs
@@ -234,13 +234,36 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
                     }
                 }
                 // Key deleted in source, still exists in dest
-                (Some(_base), None, Some(_dest)) => {
-                    // Source deleted it - apply deletion
-                    merge_results.push(crate::diff::MergeResult::Removed(key));
+                (Some(base), None, Some(dest)) => {
+                    if base == dest {
+                        // Destination unchanged from base - safe to apply source deletion
+                        merge_results.push(crate::diff::MergeResult::Removed(key));
+                    } else {
+                        // Destination modified while source deleted - conflict
+                        let conflict = crate::diff::MergeConflict {
+                            key: key.clone(),
+                            base_value: Some(base.clone()),
+                            source_value: None,
+                            destination_value: Some(dest.clone()),
+                        };
+                        merge_results.push(crate::diff::MergeResult::Conflict(conflict));
+                    }
                 }
                 // Key deleted in dest, still exists in source - keep deletion (no-op)
-                (Some(_base), Some(_source), None) => {
-                    continue;
+                (Some(base), Some(source), None) => {
+                    if base == source {
+                        // Source unchanged from base - keep destination deletion
+                        continue;
+                    } else {
+                        // Source modified while destination deleted - conflict
+                        let conflict = crate::diff::MergeConflict {
+                            key: key.clone(),
+                            base_value: Some(base.clone()),
+                            source_value: Some(source.clone()),
+                            destination_value: None,
+                        };
+                        merge_results.push(crate::diff::MergeResult::Conflict(conflict));
+                    }
                 }
                 // Key deleted in both - no-op
                 (Some(_base), None, None) => {

--- a/src/git/versioned_store/history.rs
+++ b/src/git/versioned_store/history.rs
@@ -506,13 +506,36 @@ where
                     }
                 }
                 // Key deleted in source, still exists in dest
-                (Some(_base), None, Some(_dest)) => {
-                    // Source deleted it - apply deletion
-                    merge_results.push(crate::diff::MergeResult::Removed(key.clone()));
+                (Some(base), None, Some(dest)) => {
+                    if base == dest {
+                        // Destination unchanged from base - safe to apply source deletion
+                        merge_results.push(crate::diff::MergeResult::Removed(key.clone()));
+                    } else {
+                        // Destination modified while source deleted - conflict
+                        let conflict = crate::diff::MergeConflict {
+                            key: key.clone(),
+                            base_value: Some(base.clone()),
+                            source_value: None,
+                            destination_value: Some(dest.clone()),
+                        };
+                        merge_results.push(crate::diff::MergeResult::Conflict(conflict));
+                    }
                 }
                 // Key deleted in dest, still exists in source - keep deletion (no-op)
-                (Some(_base), Some(_source), None) => {
-                    continue;
+                (Some(base), Some(source), None) => {
+                    if base == source {
+                        // Source unchanged from base - keep destination deletion
+                        continue;
+                    } else {
+                        // Source modified while destination deleted - conflict
+                        let conflict = crate::diff::MergeConflict {
+                            key: key.clone(),
+                            base_value: Some(base.clone()),
+                            source_value: Some(source.clone()),
+                            destination_value: None,
+                        };
+                        merge_results.push(crate::diff::MergeResult::Conflict(conflict));
+                    }
                 }
                 // Key deleted in both - no-op
                 (Some(_base), None, None) => {

--- a/tests/conflict_resolvers.rs
+++ b/tests/conflict_resolvers.rs
@@ -18,8 +18,19 @@ limitations under the License.
 
 mod common;
 
-use prollytree::diff::{IgnoreConflictsResolver, TakeDestinationResolver, TakeSourceResolver};
-use prollytree::git::versioned_store::GitVersionedKvStore;
+use prollytree::diff::{
+    ConflictResolver, IgnoreConflictsResolver, MergeConflict, MergeResult, TakeDestinationResolver,
+    TakeSourceResolver,
+};
+use prollytree::git::versioned_store::{GitVersionedKvStore, InMemoryVersionedKvStore};
+
+struct LeaveUnresolved;
+
+impl ConflictResolver for LeaveUnresolved {
+    fn resolve_conflict(&self, _conflict: &MergeConflict) -> Option<MergeResult> {
+        None
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Helper: set up divergent branches with a conflict on a shared key
@@ -229,6 +240,39 @@ fn test_mixed_adds_deletes_conflicts() {
     assert_eq!(store.get(b"D"), Some(b"main_d".to_vec()));
     // E: added by feature
     assert_eq!(store.get(b"E"), Some(b"feat_e".to_vec()));
+
+    std::mem::forget(_temp);
+}
+
+#[test]
+fn test_delete_modify_merge_surfaces_conflict_and_preserves_destination() {
+    let (_temp, dataset) = common::setup_repo_and_dataset();
+    let mut store = InMemoryVersionedKvStore::<32>::init(&dataset).expect("init");
+
+    store.insert(b"K".to_vec(), b"v0".to_vec()).unwrap();
+    store.commit("base").unwrap();
+    store.create_branch("feature").unwrap();
+    store.checkout_generic("main").unwrap();
+
+    store.insert(b"K".to_vec(), b"v1".to_vec()).unwrap();
+    store.commit("main modifies K").unwrap();
+
+    store.checkout_generic("feature").unwrap();
+    assert!(store.delete(b"K").unwrap());
+    store.commit("feature deletes K").unwrap();
+
+    store.checkout_generic("main").unwrap();
+    let result = store.merge_generic("feature", &LeaveUnresolved);
+
+    assert!(
+        result.is_err(),
+        "delete/modify merge must surface an unresolved conflict"
+    );
+    assert_eq!(
+        store.get(b"K"),
+        Some(b"v1".to_vec()),
+        "destination modification must not be silently deleted"
+    );
 
     std::mem::forget(_temp);
 }


### PR DESCRIPTION
# Merge Delete/Modify Conflict

## Bug

The flat versioned store merge logic treated delete/modify collisions as if the
delete should win. If one branch deleted a key while the destination branch
modified the same key from the base value, merge produced a removal instead of a
conflict. The mirror case, where destination deleted and source modified, also
failed to surface a conflict.

## Impact

This caused silent data loss during merges. A destination-side committed update
could disappear just because the source branch deleted the same key. The
namespaced merge path already had the correct conflict behavior, so the flat
store path was inconsistent with the rest of the project.

## Fix

The flat merge logic now compares source and destination values against the base.
It applies a deletion only when the other side is unchanged from base. If the
other side changed, it emits a `MergeConflict` so the configured conflict
resolver decides the outcome.

The fix was applied to both flat Git-backed and generic history merge paths so
their behavior stays aligned.

## Regression Proof

`test_delete_modify_merge_surfaces_conflict_and_preserves_destination` creates a
base key, modifies it on `main`, deletes it on a feature branch, and merges with
a resolver that leaves conflicts unresolved. The test asserts merge returns an
error and the destination modification remains present.

Against the pre-fix implementation, the merge silently removed the destination
value. The fixed branch surfaces the conflict instead.

## Verification

Verified on `fix/merge-delete-modify-conflict` during the bug-fix campaign:

- `cargo test --test conflict_resolvers test_delete_modify_merge_surfaces_conflict_and_preserves_destination`
- `cargo test --features "git sql proximity"`
- `cargo build --all`
- `cargo clippy --all`
- `cargo fmt --all -- --check`
