### PR TITLE
fix: reject malformed namespaced hash mappings

### DIFF
--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -1883,30 +1883,42 @@ impl<const N: usize> NamespacedKvStore<N, GitNodeStorage<N>, GitMetadataBackend>
         // Load from both mapping files
         for path in [&ns_mapping_path, &global_mapping_path] {
             if let Ok(data) = self.inner.metadata.read_file_at_commit(commit_id, path) {
-                let mapping_str = String::from_utf8(data).unwrap_or_default();
-                for line in mapping_str.lines() {
-                    if let Some((hash_hex, object_hex)) = line.split_once(':') {
-                        if hash_hex.len() == N * 2 {
-                            let mut hash_bytes = Vec::new();
-                            for i in 0..N {
-                                if let Ok(byte) =
-                                    u8::from_str_radix(&hash_hex[i * 2..i * 2 + 2], 16)
-                                {
-                                    hash_bytes.push(byte);
-                                } else {
-                                    break;
-                                }
-                            }
-                            if hash_bytes.len() == N {
-                                if let Ok(object_id) =
-                                    gix::ObjectId::from_hex(object_hex.as_bytes())
-                                {
-                                    let hash = ValueDigest::raw_hash(&hash_bytes);
-                                    hash_mappings.insert(hash, object_id);
-                                }
-                            }
-                        }
+                let mapping_str = String::from_utf8(data).map_err(|e| {
+                    GitKvError::GitObjectError(format!("Invalid UTF-8 in {path}: {e}"))
+                })?;
+                for (line_index, line) in mapping_str.lines().enumerate() {
+                    if line.trim().is_empty() {
+                        continue;
                     }
+
+                    let line_number = line_index + 1;
+                    let (hash_hex, object_hex) = line.split_once(':').ok_or_else(|| {
+                        GitKvError::GitObjectError(format!(
+                            "Malformed hash mapping in {path} on line {line_number}"
+                        ))
+                    })?;
+
+                    if hash_hex.len() != N * 2 {
+                        return Err(GitKvError::GitObjectError(format!(
+                            "Invalid prolly hash in {path} on line {line_number}: expected {} hex chars, got {}",
+                            N * 2,
+                            hash_hex.len()
+                        )));
+                    }
+
+                    let hash_bytes = hex::decode(hash_hex).map_err(|e| {
+                        GitKvError::GitObjectError(format!(
+                            "Invalid prolly hash in {path} on line {line_number}: {e}"
+                        ))
+                    })?;
+                    let object_id =
+                        gix::ObjectId::from_hex(object_hex.as_bytes()).map_err(|e| {
+                            GitKvError::GitObjectError(format!(
+                                "Invalid git object id in {path} on line {line_number}: {e}"
+                            ))
+                        })?;
+                    let hash = ValueDigest::raw_hash(&hash_bytes);
+                    hash_mappings.insert(hash, object_id);
                 }
             }
         }

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -219,12 +219,13 @@ mod proof_tests {
 
 #[cfg(test)]
 mod tests {
+    use crate::diff::IgnoreConflictsResolver;
     use crate::git::types::DiffOperation;
     #[cfg(feature = "rocksdb_storage")]
     use crate::git::versioned_store::RocksDBVersionedKvStore;
     use crate::git::versioned_store::{
-        FileVersionedKvStore, GitVersionedKvStore, HistoricalAccess, HistoricalCommitAccess,
-        InMemoryVersionedKvStore, ThreadSafeGitVersionedKvStore,
+        FileVersionedKvStore, GitNamespacedKvStore, GitVersionedKvStore, HistoricalAccess,
+        HistoricalCommitAccess, InMemoryVersionedKvStore, ThreadSafeGitVersionedKvStore,
     };
     use tempfile::TempDir;
 
@@ -266,6 +267,67 @@ mod tests {
         let _cwd = CwdGuard::set(&dataset_dir);
         let store = GitVersionedKvStore::<32>::init(&dataset_dir);
         assert!(store.is_ok());
+    }
+
+    #[test]
+    fn namespaced_merge_rejects_invalid_committed_hash_mapping_entry() {
+        let temp_dir = TempDir::new().unwrap();
+        gix::init(temp_dir.path()).unwrap();
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        std::process::Command::new("git")
+            .args(["config", "user.name", "ProllyTree Test"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git config user.name");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "prollytree@example.test"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git config user.email");
+
+        let mut store = GitNamespacedKvStore::<32>::init(&dataset_dir).unwrap();
+        store
+            .namespace("personal")
+            .insert(b"base".to_vec(), b"base-value".to_vec())
+            .unwrap();
+        store.commit("base").unwrap();
+
+        store.create_branch("feature").unwrap();
+        store
+            .namespace("personal")
+            .insert(b"feature".to_vec(), b"feature-value".to_vec())
+            .unwrap();
+        store.commit("feature data").unwrap();
+
+        let mapping_path = dataset_dir.join("prolly_hash_mappings");
+        let mut mappings = std::fs::read_to_string(&mapping_path).unwrap();
+        mappings.push_str("not-hex:also-not-a-git-object\n");
+        std::fs::write(&mapping_path, mappings).unwrap();
+
+        let add = std::process::Command::new("git")
+            .args(["add", "dataset/prolly_hash_mappings"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git add");
+        assert!(add.status.success(), "git add failed: {add:?}");
+        let commit = std::process::Command::new("git")
+            .args(["commit", "-m", "corrupt feature mappings"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git commit");
+        assert!(commit.status.success(), "git commit failed: {commit:?}");
+
+        store.checkout("main").unwrap();
+        let err = store
+            .merge("feature", &IgnoreConflictsResolver)
+            .expect_err("invalid committed mapping entries must fail merge");
+        assert!(
+            err.to_string().contains("Invalid prolly hash"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Bug #50: Namespaced Merge Silently Ignored Malformed Hash Mappings

## Summary

`GitNamespacedKvStore::merge` reconstructs namespace trees from committed
`prolly_hash_mappings` and `prolly_ns_hash_mappings` files. The parser used by that
historical merge path ignored malformed rows, invalid hashes, invalid object IDs, and
invalid UTF-8.

## Impact

A merge could succeed against a source or base commit whose mapping file was corrupt.
That made the merge result depend on a partial mapping set and hid repository corruption
from callers.

## Fix

`collect_ns_keys_at_commit` now treats malformed mapping files as fatal:

- invalid UTF-8 returns a `GitObjectError`,
- rows without a `:` delimiter return a line-specific error,
- prolly hashes with the wrong encoded length are rejected,
- invalid prolly hash hex is rejected,
- invalid Git object IDs are rejected.

Missing mapping files still behave as before because older commits can legitimately lack
one of the namespace/global mapping files.

## Regression Coverage

The regression test creates a namespaced Git store, commits a base namespace, creates a
feature branch with an additional namespace key, corrupts the feature branch's committed
`dataset/prolly_hash_mappings`, then verifies that merging `feature` into `main` returns
an `Invalid prolly hash` error instead of creating a merge commit.

## Verification

- RED: `CARGO_TARGET_DIR=/tmp/prollytree-bug50-target cargo test --features "git sql" namespaced_merge_rejects_invalid_committed_hash_mapping_entry -- --nocapture`
- GREEN: same focused test after the fix.
- Nearby regression: existing namespaced merge tests that exercise committed mappings.
- Quality gates: `cargo fmt --all -- --check`, `git diff --check`, and shortcut-marker scan.
