### PR TITLE
fix: reject mismatched node insert batches

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -66,6 +66,11 @@ pub trait Node<const N: usize> {
         storage: &mut S,
         path_hashes: Vec<ValueDigest<N>>,
     ) {
+        assert_eq!(
+            keys.len(),
+            values.len(),
+            "insert_batch requires the same number of keys and values"
+        );
         for (key, value) in keys.iter().zip(values) {
             self.insert(key.clone(), value.clone(), storage, path_hashes.clone());
         }
@@ -887,6 +892,11 @@ impl<const N: usize> Node<N> for ProllyNode<N> {
         storage: &mut S,
         path_hashes: Vec<ValueDigest<N>>,
     ) {
+        assert_eq!(
+            keys.len(),
+            values.len(),
+            "insert_batch requires the same number of keys and values"
+        );
         // Sort the keys and corresponding values
         let mut key_value_pairs: Vec<(Vec<u8>, Vec<u8>)> =
             keys.iter().cloned().zip(values.iter().cloned()).collect();
@@ -1430,6 +1440,17 @@ mod tests {
 
         // Verify that both trees have the same structure
         assert_eq!(node_ref.traverse(&storage), node.traverse(&storage));
+    }
+
+    #[test]
+    #[should_panic(expected = "insert_batch requires the same number of keys and values")]
+    fn test_insert_batch_rejects_length_mismatch() {
+        let mut storage = InMemoryNodeStorage::<32>::default();
+        let mut node: ProllyNode<32> = ProllyNode::default();
+        let keys = vec![vec![1], vec![2]];
+        let values = vec![vec![10]];
+
+        node.insert_batch(&keys, &values, &mut storage, Vec::new());
     }
 
     #[test]


### PR DESCRIPTION
# Bug #45: Node Insert Batch Length Mismatch

## Summary

`Node::insert_batch` and the `ProllyNode` implementation accepted separate
`keys` and `values` slices but paired them with `zip`. When the slice lengths
differed, Rust truncated to the shorter slice and silently ignored the trailing
keys or values.

## Impact

Callers that use the lower-level node API could believe an entire batch had
been inserted when only the common prefix was applied. That is data loss at the
node boundary, and it can also hide caller bugs that should fail immediately.

## Fix

The node-level batch API now asserts that `keys.len() == values.len()` before
building any key-value pairs. The same guard is present in both the trait
default and the concrete `ProllyNode` implementation so custom implementors
using the default method and `ProllyNode` callers get the same invariant.

## Regression Coverage

`node::tests::test_insert_batch_rejects_length_mismatch` exercises the
lower-level batch API with two keys and one value. The test failed before the
fix because no panic occurred, and passes after the fix with the expected
message.

## Verification

Run:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-bug45-target cargo test --features "git sql" node::tests::test_insert_batch_rejects_length_mismatch -- --nocapture
CARGO_TARGET_DIR=/tmp/prollytree-bug45-target cargo test --features "git sql" node::tests::test_insert_rnd_order -- --nocapture
cargo fmt --all -- --check
git diff --check
```
