### PR TITLE
fix(tree): guard proof/verify against underfull internal nodes

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -540,7 +540,15 @@ impl<const N: usize, S: NodeStorage<N>> Tree<N, S> for ProllyTree<N, S> {
                     None
                 }
             } else {
+                // Mirror `ProllyNode::find`: after certain delete patterns an internal
+                // node can transiently have no children (or fewer values than keys), so
+                // guard the empty case and clamp the index instead of indexing out of
+                // bounds and panicking.
+                if node.values.is_empty() {
+                    return None;
+                }
                 let i = node.keys.iter().rposition(|k| key >= &k[..]).unwrap_or(0);
+                let i = i.min(node.values.len() - 1);
                 let child_hash = node.values[i].clone();
 
                 if let Some(child_node) =

--- a/tests/regression_proof_guard.rs
+++ b/tests/regression_proof_guard.rs
@@ -1,0 +1,82 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Regression: `generate_proof` / `verify` must not panic on an underfull
+//! internal node.
+//!
+//! Both indexed `node.values[i]` on an internal node without the empty-check +
+//! `i.min(len-1)` clamp that `ProllyNode::find` already applies, so an internal
+//! node left underfull by a delete pattern (fewer values than keys, or none)
+//! panicked with an out-of-bounds index. The fix mirrors `find`'s guard.
+
+use prollytree::config::TreeConfig;
+use prollytree::storage::InMemoryNodeStorage;
+use prollytree::tree::{ProllyTree, Tree};
+
+fn splitty_config() -> TreeConfig<32> {
+    TreeConfig {
+        min_chunk_size: 2,
+        max_chunk_size: 64,
+        pattern: 0b1111,
+        ..TreeConfig::<32>::default()
+    }
+}
+
+/// Empty-values internal node: pre-fix `generate_proof` panicked on `values[0]`.
+#[test]
+fn bug_proof_on_empty_internal_node_does_not_panic() {
+    let mut tree = ProllyTree::new(InMemoryNodeStorage::<32>::default(), splitty_config());
+    for i in 0..500u32 {
+        tree.insert(format!("key-{i:08}").into_bytes(), format!("v{i}").into_bytes());
+    }
+    assert!(!tree.root.is_leaf, "test needs a multi-level tree (internal root)");
+
+    // Simulate the transient state a delete can leave.
+    tree.root.values.clear();
+
+    let proof = tree.generate_proof(b"key-00000042");
+    let _ = tree.verify(proof, b"key-00000042", None);
+}
+
+/// Underfull (keys.len() > values.len()): `rposition` can return an index that
+/// is out of bounds for the shortened `values` vec.
+#[test]
+fn bug_proof_on_underfull_internal_node_does_not_panic() {
+    let mut tree = ProllyTree::new(InMemoryNodeStorage::<32>::default(), splitty_config());
+    for i in 0..500u32 {
+        tree.insert(format!("key-{i:08}").into_bytes(), format!("v{i}").into_bytes());
+    }
+    assert!(!tree.root.is_leaf, "test needs a multi-level tree (internal root)");
+
+    tree.root.values.pop();
+
+    let proof = tree.generate_proof(b"key-99999999");
+    let _ = tree.verify(proof, b"key-99999999", None);
+}
+
+/// Positive guard: the fix must not break proofs on an intact multi-level tree.
+#[test]
+fn proof_roundtrip_multilevel() {
+    let mut tree = ProllyTree::new(InMemoryNodeStorage::<32>::default(), splitty_config());
+    for i in 0..500u32 {
+        tree.insert(format!("key-{i:08}").into_bytes(), format!("v{i}").into_bytes());
+    }
+    let key = b"key-00000042";
+    let proof = tree.generate_proof(key);
+    assert!(tree.verify(proof, key, None), "valid proof for a present key must verify");
+
+    let absent = b"key-does-not-exist";
+    let proof = tree.generate_proof(absent);
+    assert!(!tree.verify(proof, absent, None), "absent key must not verify");
+}


### PR DESCRIPTION
# Proof Underfull Internal Node Guard

## Bug

Proof generation and proof verification traversed internal nodes with an index
derived from separator values, then indexed child/value arrays without the same
empty and clamp guards used by normal lookup. Under delete-heavy or malformed
internal-node states, this could panic while `find` returned gracefully.

## Impact

Merkle proofs are a public correctness surface. A tree shape that contains an
empty or underfull internal node should not crash proof generation or proof
verification. The old behavior turned a structural edge case into an
index-out-of-bounds panic, which could bring down callers that rely on proofs for
historical reads or verification.

## Fix

The proof traversal now mirrors the defensive behavior already used by
`ProllyNode::find`: it handles empty internal state and clamps the selected child
index before dereferencing. This keeps proof behavior aligned with lookup
behavior and avoids adding a separate traversal interpretation.

## Regression Proof

`tests/regression_proof_guard.rs` adds proof regressions for both empty and
underfull internal-node cases, plus a multilevel proof round trip. The tests
prove the proof paths no longer panic and still verify valid proofs.

Against the pre-fix code, the empty/underfull proof cases panic. The fixed branch
returns controlled proof results and keeps normal proof round trips green.

## Verification

Verified on `fix/proof-underfull-internal-node` with the focused proof guard
regressions and the branch's cargo quality gates during the bug-fix campaign:

- `cargo test --test regression_proof_guard`
- `cargo test --features "git sql proximity"`
- `cargo build --all`
- `cargo clippy --all`
- `cargo fmt --all -- --check`
