### PR TITLE
fix: reject overflowing proximity dimensions

### DIFF
--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -2481,7 +2481,7 @@ where
                     if loaded.config().dim != config.dim {
                         return Err(ProximityError::DimensionMismatch {
                             expected: loaded.config().dim,
-                            got: config.dim,
+                            got: usize::from(config.dim),
                         });
                     }
                     loaded

--- a/src/proximity/embedder.rs
+++ b/src/proximity/embedder.rs
@@ -40,7 +40,7 @@ pub enum EmbedError {
     /// The embedder produced a vector of the wrong dimension. This is a bug
     /// in the embedder; surface it so the index can refuse the value.
     #[error("embed produced wrong dim: expected {expected}, got {got}")]
-    DimensionMismatch { expected: u16, got: u16 },
+    DimensionMismatch { expected: u16, got: usize },
 }
 
 /// Text-to-vector embedder.

--- a/src/proximity/index.rs
+++ b/src/proximity/index.rs
@@ -87,7 +87,7 @@ impl Default for ProximityConfig {
 pub enum ProximityError {
     /// Inserted or queried vector has the wrong dimensionality.
     #[error("dimension mismatch: index expects {expected}, got {got}")]
-    DimensionMismatch { expected: u16, got: u16 },
+    DimensionMismatch { expected: u16, got: usize },
     /// `dim` was zero in [`ProximityConfig`] — must be set before insert.
     #[error("ProximityConfig.dim must be > 0")]
     ZeroDim,
@@ -366,10 +366,10 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
         entries: BTreeMap<Vec<u8>, Vec<f32>>,
     ) -> Result<(), ProximityError> {
         for v in entries.values() {
-            if v.len() as u16 != self.config.dim {
+            if v.len() != usize::from(self.config.dim) {
                 return Err(ProximityError::DimensionMismatch {
                     expected: self.config.dim,
-                    got: v.len() as u16,
+                    got: v.len(),
                 });
             }
         }
@@ -491,10 +491,10 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
         if self.config.dim == 0 {
             return Err(ProximityError::ZeroDim);
         }
-        if vector.len() as u16 != self.config.dim {
+        if vector.len() != usize::from(self.config.dim) {
             return Err(ProximityError::DimensionMismatch {
                 expected: self.config.dim,
-                got: vector.len() as u16,
+                got: vector.len(),
             });
         }
         Ok(())
@@ -836,6 +836,26 @@ mod tests {
         idx.insert(b"x".to_vec(), vec![1.0; 4]).unwrap();
         let err = idx.knn(&[0.0, 0.0], 5, 32).unwrap_err();
         assert!(matches!(err, ProximityError::DimensionMismatch { .. }));
+    }
+
+    #[test]
+    fn dimension_validation_rejects_lengths_that_wrap_u16() {
+        let mut idx = ProximityIndex::<32, _>::new_in_memory(config(1, Metric::L2));
+        idx.insert(b"x".to_vec(), vec![1.0]).unwrap();
+
+        let too_long = vec![0.0; usize::from(u16::MAX) + 2];
+        let err = idx.insert(b"too-long".to_vec(), too_long).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "dimension mismatch: index expects 1, got 65537"
+        );
+
+        let too_long_query = vec![0.0; usize::from(u16::MAX) + 2];
+        let err = idx.knn(&too_long_query, 1, 1).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "dimension mismatch: index expects 1, got 65537"
+        );
     }
 
     #[test]

--- a/src/proximity/text_index.rs
+++ b/src/proximity/text_index.rs
@@ -435,10 +435,10 @@ impl<const N: usize, E: Embedder, S: NodeStorage<N>> TextIndex<N, E, S> {
         }
         for (idx, chunk_text) in chunks.iter().enumerate() {
             let vec = self.embedder.embed(chunk_text)?;
-            if vec.len() as u16 != self.embedder.dim() {
+            if vec.len() != usize::from(self.embedder.dim()) {
                 return Err(TextIndexError::Embed(EmbedError::DimensionMismatch {
                     expected: self.embedder.dim(),
-                    got: vec.len() as u16,
+                    got: vec.len(),
                 }));
             }
             let chunk_id = make_chunk_id(id, idx as u32);

--- a/src/python.rs
+++ b/src/python.rs
@@ -2534,7 +2534,7 @@ impl Embedder for CallableEmbedderImpl {
             if vec.len() != self.dim as usize {
                 return Err(crate::proximity::EmbedError::DimensionMismatch {
                     expected: self.dim,
-                    got: vec.len() as u16,
+                    got: vec.len(),
                 });
             }
             Ok(vec)


### PR DESCRIPTION
Isolated fix off current `main`, no unrelated changes. Includes a regression test.
