### PR TITLE
fix(proximity): skip empty index buckets

### DIFF
--- a/src/proximity/index.rs
+++ b/src/proximity/index.rs
@@ -271,6 +271,9 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
         let mut beam: Vec<(f32, ValueDigest<N>)> = vec![(0.0, root_hash)];
 
         loop {
+            if beam.is_empty() {
+                return Ok(Vec::new());
+            }
             let head_is_leaf = self.load_node(&beam[0].1)?.is_leaf();
             if head_is_leaf {
                 break;
@@ -287,6 +290,9 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
             dedup_keep_min(&mut next);
             next.sort_by(|a, b| f32_total_cmp(a.0, b.0));
             next.truncate(ef);
+            if next.is_empty() {
+                return Ok(Vec::new());
+            }
             beam = next;
         }
 
@@ -422,6 +428,9 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
         if level == 0 {
             return self.build_leaf(entries);
         }
+        if entries.is_empty() {
+            return self.build_leaf(entries);
+        }
 
         let boundary_indices: Vec<usize> = entries
             .iter()
@@ -429,10 +438,9 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
             .filter(|(_, e)| e.level >= level)
             .map(|(i, _)| i)
             .collect();
-        debug_assert!(
-            !boundary_indices.is_empty(),
-            "build_subtree at level {level} found no boundaries"
-        );
+        if boundary_indices.is_empty() {
+            return self.build_subtree(entries, level - 1);
+        }
 
         let boundaries: Vec<(Vec<u8>, Vec<f32>)> = boundary_indices
             .iter()
@@ -447,13 +455,18 @@ impl<const N: usize, S: NodeStorage<N>> ProximityIndex<N, S> {
         }
 
         let mut child_hashes = Vec::with_capacity(boundaries.len());
-        for bucket in &buckets {
+        let mut ids = Vec::with_capacity(boundaries.len());
+        let mut vecs = Vec::with_capacity(boundaries.len());
+        for (bucket, (id, vector)) in buckets.iter().zip(boundaries.iter()) {
+            if bucket.is_empty() {
+                continue;
+            }
             let h = self.build_subtree(bucket, level - 1)?;
             child_hashes.push(h);
+            ids.push(id.clone());
+            vecs.push(vector.clone());
         }
 
-        let ids: Vec<Vec<u8>> = boundaries.iter().map(|(id, _)| id.clone()).collect();
-        let vecs: Vec<Vec<f32>> = boundaries.iter().map(|(_, v)| v.clone()).collect();
         let node = ProximityNode::new(level, ids, vecs, child_hashes, dim, metric_tag);
         self.persist_node(node)
     }

--- a/tests/proximity_empty_bucket.rs
+++ b/tests/proximity_empty_bucket.rs
@@ -1,0 +1,75 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#![cfg(feature = "proximity")]
+
+use prollytree::proximity::{vector_level, Metric, ProximityConfig, ProximityIndex};
+use std::collections::BTreeMap;
+
+fn config() -> ProximityConfig {
+    ProximityConfig {
+        dim: 2,
+        metric: Metric::InnerProduct,
+        level_bits: 1,
+        max_bucket_size: 64,
+    }
+}
+
+fn promoted_collinear_pair() -> ((Vec<u8>, Vec<f32>), (Vec<u8>, Vec<f32>)) {
+    let high_vector = vec![10.0, 0.0];
+    let low_vector = vec![1.0, 0.0];
+    let mut high_by_level: BTreeMap<u8, Vec<Vec<u8>>> = BTreeMap::new();
+    let mut low_by_level: BTreeMap<u8, Vec<Vec<u8>>> = BTreeMap::new();
+
+    for i in 0..20_000u32 {
+        let high_id = format!("high-{i:05}").into_bytes();
+        let high_level = vector_level(&high_id, &high_vector, 1);
+        if high_level > 0 {
+            high_by_level.entry(high_level).or_default().push(high_id);
+        }
+
+        let low_id = format!("low-{i:05}").into_bytes();
+        let low_level = vector_level(&low_id, &low_vector, 1);
+        if low_level > 0 {
+            low_by_level.entry(low_level).or_default().push(low_id);
+        }
+    }
+
+    for (level, high_ids) in high_by_level.iter().rev() {
+        if let Some(low_ids) = low_by_level.get(level) {
+            return (
+                (high_ids[0].clone(), high_vector),
+                (low_ids[0].clone(), low_vector),
+            );
+        }
+    }
+
+    panic!("test fixture could not find a promoted collinear pair");
+}
+
+#[test]
+fn inner_product_empty_bucket_does_not_drop_knn_results() {
+    let ((high_id, high_vector), (low_id, low_vector)) = promoted_collinear_pair();
+    let mut index = ProximityIndex::<32, _>::new_in_memory(config());
+    index.insert(high_id, high_vector).unwrap();
+    index.insert(low_id.clone(), low_vector).unwrap();
+
+    let hits = index.knn(&[-1.0, 0.0], 1, 1).unwrap();
+
+    assert_eq!(
+        hits.first().map(|(id, _)| id),
+        Some(&low_id),
+        "empty boundary buckets must not consume the beam or drop populated siblings"
+    );
+}


### PR DESCRIPTION
# Proximity Search Skips Empty Buckets

## Bug

`ProximityIndex::build_subtree` could persist empty child buckets when promoted vectors shared a level but bucket assignment left gaps. `knn` then carried those empty buckets in the beam and could return no useful result even though populated sibling buckets existed.

## Impact

Approximate nearest-neighbour search could drop valid candidates. The failure is particularly visible with `Metric::InnerProduct`: a query can first enter an empty promoted boundary bucket and lose the populated sibling that contains the actual nearest item.

## Root Cause

The tree builder allocated one bucket per boundary and stored every bucket, including empty ones. Query traversal assumed every child bucket represented reachable vector data. Empty children consumed beam slots without contributing results.

## Regression Proof

`inner_product_empty_bucket_does_not_drop_knn_results` constructs a deterministic pair of promoted collinear vectors and searches with a narrow beam. On `main`, the empty boundary bucket can consume the beam and the expected low-vector result is dropped.

## Fix

The branch skips empty buckets while building proximity subtrees. Traversal also handles an empty next beam defensively by returning an empty result instead of continuing into invalid state.

The change preserves deterministic tree shape for populated buckets and avoids adding special-case scoring rules to query time.

## Verification

Run from a temporary target directory:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-target cargo test --features proximity inner_product_empty_bucket_does_not_drop_knn_results -- --nocapture
CARGO_TARGET_DIR=/tmp/prollytree-target cargo test --features proximity --test proximity_empty_bucket
```
