### PR TITLE
fix: update rocksdb test node fixture

### DIFF
--- a/src/rocksdb/storage.rs
+++ b/src/rocksdb/storage.rs
@@ -325,6 +325,7 @@ mod tests {
             level: 0,
             base: config.base,
             modulus: config.modulus,
+            content_hash: config.content_hash,
             min_chunk_size: config.min_chunk_size,
             max_chunk_size: config.max_chunk_size,
             pattern: config.pattern,
@@ -418,7 +419,7 @@ mod tests {
         let hash1 = node1.get_hash();
 
         // Insert and verify it's cached
-        storage.insert_node(hash1.clone(), node1.clone());
+        assert!(storage.insert_node(hash1.clone(), node1.clone()).is_ok());
 
         // Accessing should be from cache (we can't directly test this, but it should be fast)
         assert!(storage.get_node_by_hash(&hash1).is_some());


### PR DESCRIPTION
# Bug #57: RocksDB Storage Test Node Missing Content Hash

## Bug

`cargo check --all-targets --no-default-features --features rocksdb_storage`
failed because the RocksDB storage test helper still built `ProllyNode`
without the required `content_hash` field.

## Impact

The RocksDB feature could not be checked or tested independently with default
features disabled, which made the optional persistent storage backend appear
broken even though the missing field was in the test-only node fixture.

## Fix

The RocksDB test fixture now copies `config.content_hash` into constructed test
nodes, matching the rest of the tree and benchmark node builders.

## Verification

```bash
CARGO_TARGET_DIR=/tmp/prollytree-bug57-rocksdb \
  cargo check --all-targets --no-default-features --features rocksdb_storage
```

Also checked:

- `cargo fmt --all -- --check`
- `git diff --check`
- shortcut-marker scan

The narrower RocksDB unit test command was started, but the cold
`librocksdb-sys` native build was still compiling after an extended wait and
was interrupted. The all-target feature check above is the regression proof for
the compile error that exposed this bug.
