### PR TITLE
fix: initialize sql benchmark git repos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ harness = false
 [[bench]]
 name = "sql"
 harness = false
-required-features = ["sql"]
+required-features = ["git", "sql"]
 
 [[bench]]
 name = "git"

--- a/benches/git.rs
+++ b/benches/git.rs
@@ -30,6 +30,16 @@ use prollytree::tree::{ProllyTree, Tree};
 use tempfile::TempDir;
 
 #[cfg(all(feature = "git", feature = "sql"))]
+fn init_sql_bench_storage() -> (ProllyStorage<32>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    gix::init(temp_dir.path()).unwrap();
+    let dataset_dir = temp_dir.path().join("dataset");
+    std::fs::create_dir_all(&dataset_dir).unwrap();
+    let storage = ProllyStorage::<32>::init(&dataset_dir).unwrap();
+    (storage, temp_dir)
+}
+
+#[cfg(all(feature = "git", feature = "sql"))]
 fn generate_versioned_data(
     versions: usize,
     records_per_version: usize,
@@ -106,8 +116,7 @@ fn bench_git_sql_integration(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     runtime.block_on(async {
-                        let temp_dir = TempDir::new().unwrap();
-                        let storage = ProllyStorage::<32>::init(temp_dir.path()).unwrap();
+                        let (storage, temp_dir) = init_sql_bench_storage();
                         let mut glue = Glue::new(storage);
 
                         // Create table with versioning in mind
@@ -274,8 +283,7 @@ fn bench_sql_time_travel_queries(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     runtime.block_on(async {
-                        let temp_dir = TempDir::new().unwrap();
-                        let storage = ProllyStorage::<32>::init(temp_dir.path()).unwrap();
+                        let (storage, temp_dir) = init_sql_bench_storage();
                         let mut glue = Glue::new(storage);
 
                         // Create table
@@ -341,8 +349,7 @@ fn bench_concurrent_operations(c: &mut Criterion) {
 
             b.iter(|| {
                 runtime.block_on(async {
-                    let temp_dir = TempDir::new().unwrap();
-                    let storage = ProllyStorage::<32>::init(temp_dir.path()).unwrap();
+                    let (storage, _temp_dir) = init_sql_bench_storage();
                     let mut glue = Glue::new(storage);
 
                     // Create tables sequentially (GlueSQL doesn't support concurrent operations well)

--- a/benches/sql.rs
+++ b/benches/sql.rs
@@ -22,9 +22,18 @@ use prollytree::sql::ProllyStorage;
 use tempfile::TempDir;
 
 #[cfg(feature = "sql")]
-async fn setup_database(record_count: usize) -> (Glue<ProllyStorage<32>>, TempDir) {
+fn init_sql_bench_storage() -> (ProllyStorage<32>, TempDir) {
     let temp_dir = TempDir::new().unwrap();
-    let storage = ProllyStorage::<32>::init(temp_dir.path()).unwrap();
+    gix::init(temp_dir.path()).unwrap();
+    let dataset_dir = temp_dir.path().join("dataset");
+    std::fs::create_dir_all(&dataset_dir).unwrap();
+    let storage = ProllyStorage::<32>::init(&dataset_dir).unwrap();
+    (storage, temp_dir)
+}
+
+#[cfg(feature = "sql")]
+async fn setup_database(record_count: usize) -> (Glue<ProllyStorage<32>>, TempDir) {
+    let (storage, temp_dir) = init_sql_bench_storage();
     let mut glue = Glue::new(storage);
 
     // Create table
@@ -64,8 +73,7 @@ fn bench_sql_insert(c: &mut Criterion) {
 
             b.iter(|| {
                 runtime.block_on(async {
-                    let temp_dir = TempDir::new().unwrap();
-                    let storage = ProllyStorage::<32>::init(temp_dir.path()).unwrap();
+                    let (storage, _temp_dir) = init_sql_bench_storage();
                     let mut glue = Glue::new(storage);
 
                     // Create table


### PR DESCRIPTION
# Bug #51: SQL Benchmarks Initialized Outside a Git Repository

## Summary

The SQL Criterion benchmarks created a `TempDir` and passed that directory directly to
`ProllyStorage::init`. `ProllyStorage` is backed by `ThreadSafeGitVersionedKvStore`, so it
requires an initialized Git repository and the usual dataset subdirectory.

## Impact

The SQL benchmark targets did not measure SQL performance at all. They panicked during
setup with:

```text
Failed to initialize store: Git object error: Not inside a git repository.
```

The same setup bug affected the SQL-oriented cases inside `benches/git.rs`.

## Fix

Both benchmark files now use a benchmark-local setup helper that:

1. creates a temporary directory,
2. initializes a Git repository in it with `gix::init`,
3. creates a `dataset/` subdirectory,
4. initializes `ProllyStorage` from that dataset path.

This keeps the fix scoped to the harness and preserves the existing `ProllyStorage`
contract.

The `sql` benchmark target also now declares `required-features = ["git", "sql"]`.
That matches `ProllyStorage`'s current Git-backed implementation and prevents an
sql-only benchmark build from advertising an unsupported feature combination.

## Regression Coverage

The previously failing exact benchmark case is the regression proof:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-bug51-target \
  cargo bench -q --features "git sql" --bench sql -- \
  sql_insert/100 --exact --sample-size 10 --warm-up-time 0.03 \
  --measurement-time 0.1 --noplot --discard-baseline --quiet \
  --output-format bencher
```

Nearby coverage runs SQL cases that also use `ProllyStorage` setup:
`sql_select/100`, `git_sql_integration/100`, and `concurrent_operations/50`.

`sql_time_travel/100` now passes the old setup point and exposes a separate
benchmark-query bug: the benchmark uses unsupported `DATE_TRUNC`. That is tracked as the
next bug candidate rather than bundled into this harness setup fix.

## Verification

- RED: `sql_insert/100` panicked before the fix.
- GREEN: focused SQL benchmark after the fix.
- Nearby GREEN: `sql_select/100`, `git_sql_integration/100`, and
  `concurrent_operations/50` after the fix.
- Feature contract: `cargo check --no-default-features --features "sql" --bench sql`
  fails because `src/sql.rs` imports the Git-backed store, so the benchmark requires
  both `git` and `sql`.
- Quality gates: `cargo fmt --all -- --check`, `git diff --check`, and shortcut-marker scan.
