### PR TITLE
fix: require git feature for sql example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ path = "examples/proof.rs"
 [[example]]
 name = "sql"
 path = "examples/sql.rs"
-required-features = ["sql"]
+required-features = ["git", "sql"]
 
 [[example]]
 name = "versioning"

--- a/examples/sql.rs
+++ b/examples/sql.rs
@@ -271,6 +271,6 @@ fn print_results(title: &str, payloads: &Vec<Payload>) {
 
 #[cfg(not(feature = "sql"))]
 fn main() {
-    println!("❌ This example requires the 'sql' feature to be enabled.");
-    println!("   Run with: cargo run --example sql_example --features sql");
+    println!("❌ This example requires the 'git' and 'sql' features to be enabled.");
+    println!("   Run with: cargo run --example sql --features \"git sql\"");
 }


### PR DESCRIPTION
# Bug #55: SQL Example Advertised an Unsupported sql-only Feature Set

## Summary

The `sql` example uses `ProllyStorage`, which is backed by
`ThreadSafeGitVersionedKvStore`. That means the example needs both `git` and `sql`
features, but `Cargo.toml` declared only:

```toml
required-features = ["sql"]
```

## Impact

With default features disabled, Cargo attempted to build the example with `sql`
alone and failed inside `src/sql.rs` because `crate::git` was not compiled:

```text
error[E0433]: cannot find `git` in `crate`
```

The example fallback text also suggested `cargo run --example sql_example`, but
the actual example name is `sql`.

## Fix

The example target now declares:

```toml
required-features = ["git", "sql"]
```

The fallback hint now points at:

```bash
cargo run --example sql --features "git sql"
```

## Regression Coverage

The feature-contract check is the regression proof:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-bug55-target \
  cargo check --no-default-features --features "sql" --example sql
```

After the fix, Cargo rejects that unsupported feature set at the target gate and
prints that the `sql` example requires `git` and `sql`.

## Verification

- RED: sql-only example build failed in `src/sql.rs` with missing `crate::git`.
- GREEN: the same command now fails early with Cargo's target `required-features` message.
- Positive build: `cargo check --no-default-features --features "git sql" --example sql`.
- Execution: `cargo run -q --no-default-features --features "git sql" --example sql`
  completed successfully.
- Quality gates: `cargo fmt --all -- --check`, `git diff --check`, and shortcut-marker scan.
