### PR TITLE
fix: make sql feature enable git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,14 @@ digest_base64 = ["dep:base64"]
 prolly_balance_max_nodes = []
 prolly_balance_rolling_hash = []
 git = ["dep:gix", "dep:clap", "dep:lru", "dep:hex", "dep:chrono", "dep:uuid"]
-sql = ["dep:gluesql-core", "dep:async-trait", "dep:uuid", "dep:futures", "dep:tokio"]
+sql = [
+    "git",
+    "dep:gluesql-core",
+    "dep:async-trait",
+    "dep:uuid",
+    "dep:futures",
+    "dep:tokio",
+]
 python = ["dep:pyo3"]
 rocksdb_storage = ["dep:rocksdb", "dep:lru"]
 proximity = []

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Embedder identity (`id` + `version`) is persisted with the index. Reopening with
 | Feature | Description | Default |
 |---|---|---|
 | `git` | Git-backed versioned storage with branching, merging, history | Yes |
-| `sql` | SQL query interface via GlueSQL | Yes |
+| `sql` | SQL query interface via GlueSQL; enables `git` storage | Yes |
 | `proximity` | Vector index + text-search infrastructure (ML-free) | No |
 | `proximity_text` | Bundled Candle + all-MiniLM-L6-v2 embedder | No |
 | `rocksdb_storage` | RocksDB persistent storage backend | No |


### PR DESCRIPTION
# Bug #56: SQL Feature Enables Git

## Bug

`cargo check --all-targets --no-default-features --features sql` failed because
`src/sql.rs` imports `ThreadSafeGitVersionedKvStore`, while the `sql` feature
did not enable the `git` module that defines that store.

## Fix

The `sql` feature now depends on `git`, matching the SQL adapter's actual
storage boundary and the documented `git-prolly sql` behavior.

## Verification

```bash
CARGO_TARGET_DIR=/tmp/prollytree-bug56-sql-only \
  cargo check --all-targets --no-default-features --features sql

CARGO_TARGET_DIR=/tmp/prollytree-bug56-target \
  cargo check --all-targets --features "git sql"

CARGO_TARGET_DIR=/tmp/prollytree-bug56-sql-only \
  cargo check --no-default-features --features sql --example sql

CARGO_TARGET_DIR=/tmp/prollytree-bug56-sql-only \
  cargo test --no-default-features --features sql --lib sql::tests -- --test-threads=1

CARGO_TARGET_DIR=/tmp/prollytree-bug56-sql-only \
  cargo test --no-default-features --features sql --test sql_integration -- --test-threads=1
```
