### PR TITLE
fix: avoid unsupported sql index benchmark

### DIFF
--- a/benches/sql.rs
+++ b/benches/sql.rs
@@ -297,12 +297,8 @@ fn bench_sql_index_operations(c: &mut Criterion) {
                 || runtime.block_on(setup_database(size)),
                 |(mut glue, _temp_dir)| {
                     runtime.block_on(async {
-                        // Create index
-                        glue.execute("CREATE INDEX idx_users_age ON users(age)")
-                            .await
-                            .unwrap();
-
-                        // Query using index
+                        // ProllyStorage does not support GlueSQL CREATE INDEX; keep
+                        // this historical benchmark ID on the predicate lookup shape.
                         let result = glue
                             .execute("SELECT * FROM users WHERE age = 25")
                             .await


### PR DESCRIPTION
# Bug #53: SQL Index Benchmark Called Unsupported Index Creation

## Summary

The `sql_index` Criterion benchmark attempted to run:

```sql
CREATE INDEX idx_users_age ON users(age)
```

`ProllyStorage` implements GlueSQL's `Index` trait using the default behavior, so
index creation is currently unsupported and returns:

```text
StorageMsg("[Storage] Index::create_index is not supported")
```

## Impact

The benchmark did not measure lookup performance. It panicked before reaching the
`SELECT * FROM users WHERE age = 25` query.

## Fix

The benchmark no longer calls `CREATE INDEX`. It keeps the historical Criterion
group name, `sql_index`, so previous benchmark artifacts remain comparable, but
the measured operation is the predicate lookup shape supported by
`ProllyStorage`.

This avoids adding a misleading no-op index implementation to production code.
Real index support should be a separate feature with storage semantics and query
planner behavior, not a benchmark-only shim.

## Regression Coverage

The previously failing exact benchmark case is the regression proof:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-bug53-target \
  cargo bench -q --features "git sql" --bench sql -- \
  sql_index/100 --exact --sample-size 10 --warm-up-time 0.03 \
  --measurement-time 0.1 --noplot --discard-baseline --quiet \
  --output-format bencher
```

## Verification

- RED: `sql_index/100` panicked with unsupported `Index::create_index`.
- GREEN: `sql_index/100` runs to completion after removing the unsupported setup step.
- Nearby sweep before this bug: `sql_join/100`, `sql_aggregation/100`, `sql_update/100`,
  and `sql_delete/100` were green.
- Quality gates: `cargo fmt --all -- --check`, `git diff --check`, and shortcut-marker scan.
