### PR TITLE
fix: avoid unsupported sql benchmark function

### DIFF
--- a/benches/git.rs
+++ b/benches/git.rs
@@ -309,15 +309,15 @@ fn bench_sql_time_travel_queries(c: &mut Criterion) {
                         let result = glue.execute(
                             "SELECT
                                 metric,
-                                DATE_TRUNC('hour', timestamp) as hour,
+                                timestamp,
                                 AVG(value) as avg_value,
                                 MIN(value) as min_value,
                                 MAX(value) as max_value
                              FROM time_series
                              WHERE timestamp >= TIMESTAMP '2024-01-01 06:00:00'
                                AND timestamp <= TIMESTAMP '2024-01-01 18:00:00'
-                             GROUP BY metric, DATE_TRUNC('hour', timestamp)
-                             ORDER BY metric, hour"
+                             GROUP BY metric, timestamp
+                             ORDER BY metric, timestamp"
                         ).await.unwrap();
                         black_box(result);
                     })


### PR DESCRIPTION
# Bug #52: SQL Time-Travel Benchmark Used Unsupported `DATE_TRUNC`

## Summary

The `sql_time_travel` Criterion benchmark in `benches/git.rs` used
`DATE_TRUNC('hour', timestamp)` in both the `SELECT` list and `GROUP BY` clause.
GlueSQL routes that expression through the custom-function interface, while
`ProllyStorage` does not implement custom functions.

## Impact

After the benchmark storage setup was fixed, `sql_time_travel/100` still did not
measure query performance. It panicked during query execution with:

```text
StorageMsg("[Storage] CustomFunction is not supported")
```

## Fix

The generated benchmark data already stores one row per exact hour:

```sql
TIMESTAMP '2024-01-01 HH:00:00'
```

The query now groups and orders directly by the stored `timestamp` column instead
of calling `DATE_TRUNC`. This preserves the intended hourly aggregation while
staying inside GlueSQL functionality supported by `ProllyStorage`.

## Regression Coverage

The previously failing exact benchmark case is the regression proof:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-bug52-target \
  cargo bench -q --features "git sql" --bench git -- \
  sql_time_travel/100 --exact --sample-size 10 --warm-up-time 0.03 \
  --measurement-time 0.1 --noplot --discard-baseline --quiet \
  --output-format bencher
```

## Verification

- RED: `sql_time_travel/100` panicked with unsupported `CustomFunction`.
- GREEN: the same exact benchmark case runs to completion after the query change.
- Larger sibling: `sql_time_travel/500` also runs to completion with the same query shape.
- Quality gates: `cargo fmt --all -- --check`, `git diff --check`, and shortcut-marker scan.
