### PR TITLE
fix: compile storage benchmark with content hash

### DIFF
--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -247,6 +247,7 @@ fn bench_node_storage_direct(c: &mut Criterion) {
             merged: false,
             encode_types: Vec::new(),
             encode_values: Vec::new(),
+            content_hash: config.content_hash,
         };
         nodes.push((node.get_hash(), node));
     }


### PR DESCRIPTION
# Storage Benchmark Missing Content Hash

## Bug

`benches/storage.rs` manually constructed `ProllyNode` values for the direct
node-storage benchmark. The combined branch added `content_hash` to
`ProllyNode`, but the benchmark initializer was not updated.

## Impact

`cargo bench --bench storage` no longer compiled on the combined branch. That
blocked storage benchmark comparisons against `main` and hid the file-backed
storage performance regression discovered during the benchmark pass.

## Fix

The benchmark initializer now copies `config.content_hash` into each synthetic
node. That keeps the benchmark aligned with the configured storage/hash
algorithm and avoids changing the benchmark workload shape.

## Regression Proof

Before the fix, `cargo bench --bench storage` failed with:

`missing field content_hash in initializer of ProllyNode<_>`

After the fix, the storage benchmark target compiles successfully.

## Verification

Run on `fix/storage-bench-content-hash`:

- `CARGO_TARGET_DIR=/tmp/prollytree-bench-content-hash-target cargo bench --bench storage --no-run`
