### PR TITLE
fix: update storage benchmark node literal

### DIFF
--- a/benches/storage.rs
+++ b/benches/storage.rs
@@ -243,6 +243,7 @@ fn bench_node_storage_direct(c: &mut Criterion) {
             min_chunk_size: config.min_chunk_size,
             max_chunk_size: config.max_chunk_size,
             pattern: config.pattern,
+            content_hash: config.content_hash,
             split: false,
             merged: false,
             encode_types: Vec::new(),


### PR DESCRIPTION
# Bug #54: Storage Benchmark `ProllyNode` Literal Missed `content_hash`

## Summary

`benches/storage.rs` manually constructed `ProllyNode` values for the direct node
storage benchmark. After `ProllyNode` gained the `content_hash` field, that literal
was not updated.

## Impact

The storage benchmark target did not compile:

```text
error[E0063]: missing field `content_hash` in initializer of `ProllyNode<_>`
```

This also prevents broader all-target quality gates from reaching later checks.

## Fix

The benchmark node literal now sets:

```rust
content_hash: config.content_hash
```

That keeps the benchmark node aligned with the same `TreeConfig` values already
used for schema, chunking, and rolling-pattern fields.

## Regression Coverage

The direct compile check is the regression proof:

```bash
CARGO_TARGET_DIR=/tmp/prollytree-bug54-target cargo check --bench storage
```

## Verification

- RED: `cargo check --bench storage` failed with missing `content_hash`.
- GREEN: the same check succeeds after the initializer is updated.
- Quality gates: `cargo fmt --all -- --check`, `git diff --check`, and shortcut-marker scan.
