### PR TITLE
fix: make text cascade updates atomic

### DIFF
--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -274,14 +274,15 @@ impl<'a, const N: usize, S: NodeStorage<N>, M: MetadataBackend> NamespaceHandle<
     /// `NamespacedKvStore::set_cascade`, this also embeds `value` (as UTF-8)
     /// and upserts the resulting vector into every cascading text sub-index
     /// that is currently loaded. Targets not loaded yet, and values that
-    /// aren't valid UTF-8, are silently skipped.
+    /// aren't valid UTF-8, are silently skipped. Embedder or proximity-index
+    /// errors abort the primary insert before any staged value is changed.
     pub fn insert(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), GitKvError> {
         crate::validation::validate_kv(&key, &value)?;
         // Auto-cascade into text indexes, if configured. Done BEFORE staging
         // the primary insert so an embed error surfaces before any state has
         // been touched.
         #[cfg(feature = "proximity")]
-        self.cascade_insert(&key, &value);
+        self.cascade_insert(&key, &value)?;
 
         self.store
             .namespace_staging
@@ -323,13 +324,15 @@ impl<'a, const N: usize, S: NodeStorage<N>, M: MetadataBackend> NamespaceHandle<
     ///    non-UTF-8).
     ///
     /// Silent no-op cases otherwise: no cascade list configured, target
-    /// whose embedder/proximity-index isn't currently loaded, or the
-    /// embedder itself returns an error.
+    /// whose embedder/proximity-index isn't currently loaded, or a value that
+    /// isn't valid text for the configured target. Embedder/proximity errors
+    /// are returned before the primary value is staged.
     #[cfg(feature = "proximity")]
-    fn cascade_insert(&mut self, key: &[u8], value: &[u8]) {
+    fn cascade_insert(&mut self, key: &[u8], value: &[u8]) -> Result<(), GitKvError> {
         let Some(cascade_list) = self.store.cascade_lists.get(&self.ns_name).cloned() else {
-            return;
+            return Ok(());
         };
+        let mut planned = Vec::new();
         for idx_name in cascade_list {
             let target_key = (self.ns_name.clone(), idx_name.clone());
             let prox_key = (self.ns_name.clone(), text_inner_proximity_name(&idx_name));
@@ -350,6 +353,14 @@ impl<'a, const N: usize, S: NodeStorage<N>, M: MetadataBackend> NamespaceHandle<
             let Some(embedder) = self.store.text_embedders.get(&target_key).cloned() else {
                 continue;
             };
+            let Some(idx_dim) = self
+                .store
+                .proximity_indexes
+                .get(&prox_key)
+                .map(|idx| idx.config().dim)
+            else {
+                continue;
+            };
             let chunker: Arc<dyn Chunker> = self
                 .store
                 .text_chunkers
@@ -357,27 +368,53 @@ impl<'a, const N: usize, S: NodeStorage<N>, M: MetadataBackend> NamespaceHandle<
                 .cloned()
                 .unwrap_or_else(|| Arc::new(IdentityChunker));
 
-            // 3. Chunk → embed → insert. Drop any previous chunks for this
-            //    doc-id first so re-inserts with a different chunk count
-            //    don't leak stale entries.
-            //
-            //    Borrow gymnastics: each chunk's embed happens outside the
-            //    proximity-index borrow, then a fresh `get_mut` reborrows
-            //    for the insert. Slight overhead, but keeps the embedder
-            //    free to call into anything (incl. error-returning paths).
-            Self::cascade_delete_chunks_for_doc(self.store, &prox_key, key);
+            // 3. Chunk and embed during a full preflight pass. No target index
+            //    is mutated until every configured target has successfully
+            //    produced dimension-valid replacement vectors.
             let chunks = chunker.split(&text);
+            let mut replacements = Vec::with_capacity(chunks.len());
             for (chunk_idx, chunk_text) in chunks.iter().enumerate() {
-                let Ok(vec) = embedder.embed(chunk_text) else {
-                    continue;
-                };
-                let chunk_id = make_chunk_id(key, chunk_idx as u32);
-                if let Some(idx) = self.store.proximity_indexes.get_mut(&prox_key) {
-                    let _ = idx.insert(chunk_id, vec);
-                    self.store.dirty_proximity_indexes.insert(prox_key.clone());
+                let vec = embedder.embed(chunk_text).map_err(|e| {
+                    GitKvError::GitObjectError(format!(
+                        "Text cascade into {}/{} failed for key {:?}: {e}",
+                        self.ns_name,
+                        idx_name,
+                        String::from_utf8_lossy(key)
+                    ))
+                })?;
+                if idx_dim == 0 || vec.len() != usize::from(idx_dim) {
+                    return Err(GitKvError::GitObjectError(format!(
+                        "Text cascade into {}/{} produced vector dimension {}, expected {}",
+                        self.ns_name,
+                        idx_name,
+                        vec.len(),
+                        idx_dim
+                    )));
                 }
+                let chunk_id = make_chunk_id(key, chunk_idx as u32);
+                replacements.push((chunk_id, vec));
             }
+            planned.push((idx_name, prox_key, replacements));
         }
+
+        for (idx_name, prox_key, replacements) in planned {
+            Self::cascade_delete_chunks_for_doc(self.store, &prox_key, key);
+            let Some(idx) = self.store.proximity_indexes.get_mut(&prox_key) else {
+                continue;
+            };
+            for (chunk_id, vec) in replacements {
+                idx.insert(chunk_id, vec).map_err(|e| {
+                    GitKvError::GitObjectError(format!(
+                        "Text cascade into {}/{} failed for key {:?}: {e}",
+                        self.ns_name,
+                        idx_name,
+                        String::from_utf8_lossy(key)
+                    ))
+                })?;
+            }
+            self.store.dirty_proximity_indexes.insert(prox_key.clone());
+        }
+        Ok(())
     }
 
     /// Cascade a delete to every configured text sub-index for this

--- a/tests/text_cascade.rs
+++ b/tests/text_cascade.rs
@@ -26,12 +26,52 @@ mod common;
 
 use common::setup_repo_and_dataset;
 use prollytree::git::versioned_store::FileNamespacedKvStore;
-use prollytree::proximity::{HashEmbedder, TextIndexConfig};
+use prollytree::proximity::{EmbedError, Embedder, HashEmbedder, TextIndexConfig};
 
 const N: usize = 32;
 
 fn cfg(dim: u16, seed: u64) -> TextIndexConfig<HashEmbedder> {
     TextIndexConfig::new(HashEmbedder::new(dim, seed))
+}
+
+#[derive(Debug, Clone)]
+struct FailsOnNeedleEmbedder {
+    inner: HashEmbedder,
+    needle: &'static str,
+}
+
+impl FailsOnNeedleEmbedder {
+    fn new(dim: u16, seed: u64, needle: &'static str) -> Self {
+        Self {
+            inner: HashEmbedder::new(dim, seed),
+            needle,
+        }
+    }
+}
+
+impl Embedder for FailsOnNeedleEmbedder {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn version(&self) -> &str {
+        self.inner.version()
+    }
+
+    fn dim(&self) -> u16 {
+        self.inner.dim()
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
+        if text.contains(self.needle) {
+            return Err(EmbedError::Failure("forced cascade failure".to_string()));
+        }
+        self.inner.embed(text)
+    }
+}
+
+fn failing_cfg(dim: u16, seed: u64) -> TextIndexConfig<FailsOnNeedleEmbedder> {
+    TextIndexConfig::new(FailsOnNeedleEmbedder::new(dim, seed, "fail-cascade"))
 }
 
 #[test]
@@ -209,6 +249,87 @@ fn cascade_silently_skips_non_utf8_value() {
     assert_eq!(personal.get(b"k"), Some(bad_utf8));
     let docs = personal.text_index("docs", cfg(8, 0)).unwrap();
     assert_eq!(docs.len(), 0);
+}
+
+#[test]
+fn cascade_embed_error_preserves_primary_and_existing_chunks() {
+    let (_temp, dataset) = setup_repo_and_dataset();
+    let mut store = FileNamespacedKvStore::<N>::init(&dataset).unwrap();
+
+    {
+        let _ = store
+            .namespace("personal")
+            .text_index("docs", failing_cfg(8, 0))
+            .unwrap();
+    }
+    store.set_cascade("personal", vec!["docs".to_string()]);
+
+    {
+        let mut personal = store.namespace("personal");
+        personal
+            .insert(b"doc:1".to_vec(), b"stable text".to_vec())
+            .unwrap();
+    }
+    store.commit("initial cascade").unwrap();
+
+    {
+        let mut personal = store.namespace("personal");
+        let err = personal
+            .insert(b"doc:1".to_vec(), b"please fail-cascade".to_vec())
+            .unwrap_err();
+        assert!(err.to_string().contains("forced cascade failure"));
+        assert_eq!(personal.get(b"doc:1"), Some(b"stable text".to_vec()));
+    }
+
+    let mut personal = store.namespace("personal");
+    let mut docs = personal.text_index("docs", failing_cfg(8, 0)).unwrap();
+    assert_eq!(docs.len(), 1);
+    let hits = docs.search("stable text", 1).unwrap();
+    assert_eq!(hits[0].id, b"doc:1".to_vec());
+}
+
+#[test]
+fn cascade_embed_error_does_not_rewrite_earlier_targets() {
+    let (_temp, dataset) = setup_repo_and_dataset();
+    let mut store = FileNamespacedKvStore::<N>::init(&dataset).unwrap();
+
+    {
+        let mut personal = store.namespace("personal");
+        let _ = personal.text_index("first", cfg(8, 1)).unwrap();
+        let _ = personal.text_index("second", failing_cfg(8, 2)).unwrap();
+    }
+    store.set_cascade("personal", vec!["first".to_string(), "second".to_string()]);
+
+    {
+        let mut personal = store.namespace("personal");
+        personal
+            .insert(b"doc:1".to_vec(), b"stable text".to_vec())
+            .unwrap();
+    }
+    store.commit("initial cascade").unwrap();
+
+    {
+        let mut personal = store.namespace("personal");
+        let err = personal
+            .insert(b"doc:1".to_vec(), b"please fail-cascade".to_vec())
+            .unwrap_err();
+        assert!(err.to_string().contains("forced cascade failure"));
+        assert_eq!(personal.get(b"doc:1"), Some(b"stable text".to_vec()));
+    }
+
+    let mut personal = store.namespace("personal");
+    {
+        let mut first = personal.text_index("first", cfg(8, 1)).unwrap();
+        let hits = first.search("stable text", 1).unwrap();
+        assert_eq!(hits[0].id, b"doc:1".to_vec());
+        assert!(hits[0].score < 1e-4);
+    }
+    {
+        let mut second = personal.text_index("second", failing_cfg(8, 2)).unwrap();
+        let hits = second.search("stable text", 1).unwrap();
+        assert_eq!(hits[0].id, b"doc:1".to_vec());
+        assert!(hits[0].score < 1e-4);
+    }
 }
 
 #[test]


### PR DESCRIPTION
# Text Cascade Atomicity

## Bug

`NamespaceHandle::insert` staged the primary key/value even when automatic text
cascade indexing failed. The cascade path also deleted old chunks before all
replacement chunks had been embedded successfully, and it applied each cascade
target immediately. A failing embedder or proximity insert could therefore leave
the primary namespace and one or more text indexes disagreeing about the current
document.

## Impact

The failure was silent before this fix: cascade embedder errors were ignored.
For a reinsert, the primary value could advance while the text index still held
old chunks, no chunks, or a partially updated subset of configured targets.
Search results could then return stale documents or miss a document that was
present in the primary namespace. The bug was reachable through the public
namespaced store API whenever `set_cascade` was enabled and a loaded text index
used an embedder or chunk path that returned an error.

## Fix

The insert path now treats cascade failures as part of the same operation as the
primary write. It validates the key/value first, preflights every configured and
loaded cascade target, embeds all replacement chunks, checks dimensions against
the loaded proximity index, and only then stages index mutations. The primary
namespace write is staged after cascade preflight succeeds.

This keeps the existing documented skip behavior for targets that are not loaded,
transformers that opt out with `None`, and non-UTF-8 values without a transformer.
It changes only real error handling: embedder failures, wrong dimensions, and
proximity insert errors now abort the operation instead of being swallowed.

## Regression Proof

`tests/text_cascade.rs` adds two regression cases:

- `cascade_embed_error_preserves_primary_and_existing_chunks` proves a failed
  reinsert leaves the primary value and existing text chunks unchanged.
- `cascade_embed_error_does_not_rewrite_earlier_targets` proves one cascade
  target is not rewritten before a later configured target fails.

The first regression was run against `main` in a temporary worktree and failed
because `insert` returned `Ok(())` instead of surfacing the cascade error. The
fixed branch passes both regressions.

## Verification

Verified on `fix/text-cascade-atomicity` with `/tmp` cargo targets:

- `cargo test --features "git proximity" cascade_embed_error -- --nocapture`
- `cargo test --features "git proximity" --test text_cascade -- --nocapture`
- `cargo test --features "git proximity" --test text_multichunk --quiet`
- `cargo test --features "git sql proximity" --lib --quiet`
- `cargo build --all --message-format short`
- `cargo clippy --all --message-format short`
- `cargo fmt --all -- --check`
- `git diff --check`
