### PR TITLE
fix: validate text index tuning on reopen

### DIFF
--- a/src/proximity/text_index.rs
+++ b/src/proximity/text_index.rs
@@ -139,6 +139,14 @@ pub enum TextIndexError {
     #[error("dimension mismatch: stored index uses dim {stored}, embedder produces dim {got}")]
     DimensionMismatch { stored: u16, got: u16 },
 
+    /// The stored text-index tuning does not match the requested config.
+    #[error("config mismatch for {field}: stored {stored}, supplied {supplied}")]
+    ConfigMismatch {
+        field: &'static str,
+        stored: String,
+        supplied: String,
+    },
+
     /// The underlying [`ProximityIndex`] returned an error.
     #[error("proximity error: {0}")]
     Proximity(#[from] ProximityError),
@@ -276,6 +284,27 @@ where
             return Err(TextIndexError::DimensionMismatch {
                 stored: state.dim,
                 got: embedder.dim(),
+            });
+        }
+        if state.metric != metric {
+            return Err(TextIndexError::ConfigMismatch {
+                field: "metric",
+                stored: format!("{:?}", state.metric),
+                supplied: format!("{metric:?}"),
+            });
+        }
+        if state.level_bits != level_bits {
+            return Err(TextIndexError::ConfigMismatch {
+                field: "level_bits",
+                stored: state.level_bits.to_string(),
+                supplied: level_bits.to_string(),
+            });
+        }
+        if state.max_bucket_size != max_bucket_size {
+            return Err(TextIndexError::ConfigMismatch {
+                field: "max_bucket_size",
+                stored: state.max_bucket_size.to_string(),
+                supplied: max_bucket_size.to_string(),
             });
         }
         Ok(())

--- a/tests/text_index_namespaced.rs
+++ b/tests/text_index_namespaced.rs
@@ -141,6 +141,65 @@ fn reopen_with_different_embedder_version_returns_mismatch() {
 }
 
 #[test]
+fn reopen_with_different_tuning_returns_mismatch() {
+    use prollytree::proximity::Metric;
+
+    let (_temp, dataset) = setup_repo_and_dataset();
+    let mut store = FileNamespacedKvStore::<N>::init(&dataset).unwrap();
+    {
+        let mut personal = store.namespace("personal");
+        let mut metric_cfg = cfg(16, 0);
+        metric_cfg.metric = Metric::L2;
+        let _ = personal.text_index("metric", metric_cfg).unwrap();
+
+        let mut level_cfg = cfg(16, 0);
+        level_cfg.level_bits = 5;
+        let _ = personal.text_index("level", level_cfg).unwrap();
+
+        let mut bucket_cfg = cfg(16, 0);
+        bucket_cfg.max_bucket_size = 32;
+        let _ = personal.text_index("bucket", bucket_cfg).unwrap();
+    }
+
+    let mut personal = store.namespace("personal");
+    let err = personal.text_index("metric", cfg(16, 0)).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            TextIndexError::ConfigMismatch {
+                field: "metric",
+                ..
+            }
+        ),
+        "expected metric ConfigMismatch, got {err:?}"
+    );
+
+    let err = personal.text_index("level", cfg(16, 0)).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            TextIndexError::ConfigMismatch {
+                field: "level_bits",
+                ..
+            }
+        ),
+        "expected level_bits ConfigMismatch, got {err:?}"
+    );
+
+    let err = personal.text_index("bucket", cfg(16, 0)).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            TextIndexError::ConfigMismatch {
+                field: "max_bucket_size",
+                ..
+            }
+        ),
+        "expected max_bucket_size ConfigMismatch, got {err:?}"
+    );
+}
+
+#[test]
 fn multiple_text_indexes_per_namespace_are_independent() {
     let (_temp, dataset) = setup_repo_and_dataset();
     let mut store = FileNamespacedKvStore::<N>::init(&dataset).unwrap();


### PR DESCRIPTION
# Text Index Config Validation

## Bug

The text-index identity blob persisted embedder identity, dimension, metric,
`level_bits`, and `max_bucket_size`, but reopen validation checked only embedder
id, version, and dimension. A namespaced text index could be reopened with the
same embedder but different tuning, and the API would silently return a handle
instead of rejecting the incompatible config.

## Impact

The caller-provided `TextIndexConfig` is part of the public contract for a text
index. Accepting a mismatched metric or tree tuning makes the handle misleading:
the caller believes they opened an index with the supplied config, while the
loaded proximity index still has the persisted config. That can produce
incorrect assumptions about scoring semantics, bucket layout, and recall tuning.

The bug was reachable through the public namespaced `text_index` API. No corrupt
state was required; opening an existing index with `Metric::Cosine` after it was
created with `Metric::L2` was accepted.

## Fix

`validate_or_write_text_identity` now validates every persisted tuning field when
the state blob already exists:

- `metric`
- `level_bits`
- `max_bucket_size`

A new `TextIndexError::ConfigMismatch` variant reports the mismatched field and
the stored versus supplied value. Existing embedder mismatch and dimension
mismatch behavior is unchanged.

## Regression Proof

`reopen_with_different_tuning_returns_mismatch` creates three namespaced text
indexes with non-default metric, `level_bits`, and `max_bucket_size`, then tries
to reopen each one with the default config. The fixed branch returns
`TextIndexError::ConfigMismatch` for the relevant field.

Against `main` in a detached temporary worktree, the metric portion of the
regression failed because `personal.text_index("metric", cfg(16, 0))` returned
`Ok(_)` instead of an error.

## Verification

Verified on `fix/text-index-config-validation` with `/tmp` cargo targets:

- `cargo test --features "git proximity" reopen_with_different_tuning_returns_mismatch -- --nocapture`
- `cargo test --features "git proximity" --test text_index_namespaced -- --nocapture`
- `cargo test --features "git sql proximity"`
- `cargo build --all --message-format short`
- `cargo clippy --all --message-format short`
- `cargo fmt --all -- --check`
- `git diff --check`
