### PR TITLE
fix: make text index reindex atomic

### DIFF
--- a/src/proximity/text_index.rs
+++ b/src/proximity/text_index.rs
@@ -504,16 +504,25 @@ impl<const N: usize, E: Embedder, S: NodeStorage<N>> TextIndex<N, E, S> {
     where
         I: IntoIterator<Item = (Vec<u8>, String)>,
     {
-        // Drop every chunk in the index. Cheaper than per-doc deletion since
-        // we're rebuilding from scratch anyway.
-        let ids: Vec<Vec<u8>> = self.inner.entries_snapshot().keys().cloned().collect();
-        for id in ids {
-            self.inner.remove(&id);
-        }
-        // Re-insert each doc through the chunker.
+        let mut rebuilt =
+            ProximityIndex::new(self.inner.storage().clone(), self.inner.config().clone());
         for (id, text) in texts {
-            self.insert(&id, &text)?;
+            let chunks = self.chunker.split(&text);
+            if chunks.is_empty() {
+                continue;
+            }
+            for (idx, chunk_text) in chunks.iter().enumerate() {
+                let vec = self.embedder.embed(chunk_text)?;
+                if vec.len() as u16 != self.embedder.dim() {
+                    return Err(TextIndexError::Embed(EmbedError::DimensionMismatch {
+                        expected: self.embedder.dim(),
+                        got: vec.len() as u16,
+                    }));
+                }
+                rebuilt.insert(make_chunk_id(&id, idx as u32), vec)?;
+            }
         }
+        self.inner = rebuilt;
         Ok(())
     }
 
@@ -573,6 +582,42 @@ mod tests {
 
     fn config(dim: u16) -> TextIndexConfig<HashEmbedder> {
         TextIndexConfig::new(HashEmbedder::new(dim, 0))
+    }
+
+    #[derive(Debug, Clone)]
+    struct FailsOnNeedleEmbedder {
+        inner: HashEmbedder,
+        needle: &'static str,
+    }
+
+    impl FailsOnNeedleEmbedder {
+        fn new(dim: u16, needle: &'static str) -> Self {
+            Self {
+                inner: HashEmbedder::new(dim, 0),
+                needle,
+            }
+        }
+    }
+
+    impl Embedder for FailsOnNeedleEmbedder {
+        fn id(&self) -> &str {
+            self.inner.id()
+        }
+
+        fn version(&self) -> &str {
+            self.inner.version()
+        }
+
+        fn dim(&self) -> u16 {
+            self.inner.dim()
+        }
+
+        fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
+            if text.contains(self.needle) {
+                return Err(EmbedError::Failure("forced reindex failure".to_string()));
+            }
+            self.inner.embed(text)
+        }
     }
 
     #[test]
@@ -711,6 +756,25 @@ mod tests {
         // "a" was kept but re-embedded; "b" was dropped; "c" was added.
         let hits = idx.search("fresh c", 1).unwrap();
         assert_eq!(hits[0].id, b"c".to_vec());
+    }
+
+    #[test]
+    fn failed_reindex_preserves_existing_documents() {
+        let storage = InMemoryNodeStorage::<32>::new();
+        let mut idx = TextIndex::new(
+            storage,
+            TextIndexConfig::new(FailsOnNeedleEmbedder::new(8, "fail-reindex")),
+        );
+        idx.insert(b"doc:1", "stable text").unwrap();
+
+        let err = idx
+            .reindex_from_texts(vec![(b"doc:1".to_vec(), "please fail-reindex".to_string())])
+            .unwrap_err();
+        assert!(err.to_string().contains("forced reindex failure"));
+
+        let hits = idx.search("stable text", 1).unwrap();
+        assert_eq!(hits[0].id, b"doc:1".to_vec());
+        assert!(hits[0].score < 1e-4);
     }
 
     #[test]


### PR DESCRIPTION
# Text Index Reindex Atomicity

## Bug

`TextIndex::reindex_from_texts` cleared every existing chunk from the live index
before embedding the replacement corpus. If any replacement document failed to
embed or insert, the method returned an error after the previous searchable index
had already been destroyed.

## Impact

`reindex_from_texts` is the documented path for rebuilding an index from a
source-of-truth document store, especially after changing embedders. A failed
reindex should leave the caller with either the old index or the new index, not
an empty or partially rebuilt index. The old behavior could turn an embedder
error into search downtime or stale persistence if the caller later persisted
the damaged in-memory state.

The bug was reachable through the public standalone `TextIndex` API with any
fallible embedder. No malformed storage state was required.

## Fix

Reindex now builds into a temporary `ProximityIndex` backed by the same storage
handle and the same proximity configuration. It iterates over the supplied
`(id, text)` corpus, chunks and embeds every replacement document, inserts the
replacement chunk vectors into the temporary index, and swaps the temporary index
into `self.inner` only after the full rebuild succeeds.

Empty chunk output keeps the existing semantics: that source document is omitted
from the rebuilt index. Successful reindex still replaces the full old corpus.
The difference is failure behavior: embedder or proximity errors leave the old
index untouched.

## Regression Proof

`failed_reindex_preserves_existing_documents` inserts a document, attempts to
reindex with a failing embedder, asserts the error is surfaced, and then searches
for the original text. Against `main` in a detached temporary worktree, the test
failed because search returned no hits after the failed reindex. The fixed branch
passes the regression and the existing successful reindex test.

## Verification

Verified on `fix/text-index-reindex-atomicity` with `/tmp` cargo targets:

- `cargo test --features proximity failed_reindex_preserves_existing_documents -- --nocapture`
- `cargo test --features proximity reindex -- --nocapture`
- `cargo test --features "git sql proximity"`
- `cargo build --all --message-format short`
- `cargo clippy --all --message-format short`
- `cargo fmt --all -- --check`
- `git diff --check`
