### PR TITLE
fix: saturate text search overfetch limits

### DIFF
--- a/src/git/versioned_store/namespaced.rs
+++ b/src/git/versioned_store/namespaced.rs
@@ -55,7 +55,7 @@ use crate::storage::RocksDBNodeStorage;
 #[cfg(feature = "proximity")]
 use crate::proximity::text_index::{
     dedup_chunk_hits_by_doc, doc_id_prefix, make_chunk_id, text_inner_proximity_name,
-    text_state_key, validate_or_write_text_identity, OVERFETCH_MULTIPLIER,
+    text_search_limits, text_state_key, validate_or_write_text_identity,
 };
 #[cfg(feature = "proximity")]
 use crate::proximity::{
@@ -2672,8 +2672,7 @@ where
             return Ok(Vec::new());
         }
         let q = self.embedder.embed(query)?;
-        let raw_k = (k * OVERFETCH_MULTIPLIER).max(k);
-        let ef = (raw_k * 4).max(32);
+        let (raw_k, ef) = text_search_limits(k);
         let idx = self
             .store
             .proximity_indexes

--- a/src/proximity/text_index.rs
+++ b/src/proximity/text_index.rs
@@ -90,6 +90,12 @@ pub(crate) fn doc_id_prefix(doc_id: &[u8]) -> Vec<u8> {
 /// with many chunks don't crowd out distinct top-k results.
 pub(crate) const OVERFETCH_MULTIPLIER: usize = 4;
 
+pub(crate) fn text_search_limits(k: usize) -> (usize, usize) {
+    let raw_k = k.saturating_mul(OVERFETCH_MULTIPLIER).max(k);
+    let ef = raw_k.saturating_mul(4).max(32);
+    (raw_k, ef)
+}
+
 /// Dedup a chunk-level hit list by doc-id, keeping each doc's best score, and
 /// truncate to `k`. Used by both standalone [`TextIndex::search`] and the
 /// namespaced sub-handle.
@@ -464,8 +470,7 @@ impl<const N: usize, E: Embedder, S: NodeStorage<N>> TextIndex<N, E, S> {
         // Over-fetch chunks so the dedup-by-doc step still yields `k` docs
         // even when there are several chunks per doc. The 4× multiplier is
         // a reasonable middle ground.
-        let raw_k = (k * OVERFETCH_MULTIPLIER).max(k);
-        let ef = (raw_k * 4).max(32);
+        let (raw_k, ef) = text_search_limits(k);
         let chunk_hits = self.inner.knn(&q, raw_k, ef)?;
         Ok(dedup_chunk_hits_by_doc(chunk_hits, k))
     }
@@ -592,6 +597,17 @@ mod tests {
             "expected near-zero, got {}",
             hits[0].score
         );
+    }
+
+    #[test]
+    fn search_saturates_overfetch_for_huge_k() {
+        let storage = InMemoryNodeStorage::<32>::new();
+        let mut idx = TextIndex::new(storage, config(8));
+        idx.insert(b"doc:1", "the quick brown fox").unwrap();
+
+        let hits = idx.search("the quick brown fox", usize::MAX).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id, b"doc:1".to_vec());
     }
 
     #[test]

--- a/tests/text_index_namespaced.rs
+++ b/tests/text_index_namespaced.rs
@@ -51,6 +51,19 @@ fn text_index_insert_search_basic() {
 }
 
 #[test]
+fn text_index_search_saturates_overfetch_for_huge_k() {
+    let (_temp, dataset) = setup_repo_and_dataset();
+    let mut store = FileNamespacedKvStore::<N>::init(&dataset).unwrap();
+    let mut personal = store.namespace("personal");
+    let mut docs = personal.text_index("docs", cfg(8, 0)).unwrap();
+    docs.insert(b"doc:1", "the quick brown fox").unwrap();
+
+    let hits = docs.search("the quick brown fox", usize::MAX).unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, b"doc:1".to_vec());
+}
+
+#[test]
 fn text_index_survives_commit_and_reopen() {
     let (_temp, dataset) = setup_repo_and_dataset();
     let query = "lazy dog naps in sun";


### PR DESCRIPTION
Isolated fix off current `main`, no unrelated changes. Includes a regression test.
