### PR TITLE
fix: reject malformed versioned hash mappings

### DIFF
--- a/src/git/versioned_store/backends.rs
+++ b/src/git/versioned_store/backends.rs
@@ -748,40 +748,60 @@ impl<const N: usize> VersionedKvStore<N, GitNodeStorage<N>, GitMetadataBackend> 
         let mut hash_mappings = HashMap::new();
         let mut is_simple_mapping = false;
 
-        for line in mapping_str.lines() {
-            if let Some((prefix, rest)) = line.split_once(':') {
-                if prefix == "key" {
-                    // This is a simple key-value mapping from InMemory storage
-                    is_simple_mapping = true;
-                    if let Some((key_hex, value_hex)) = rest.split_once(':') {
-                        if let (Ok(key), Ok(value)) = (hex::decode(key_hex), hex::decode(value_hex))
-                        {
-                            key_values.insert(key, value);
-                        }
-                    }
-                } else {
-                    // This is a hash mapping from Git storage
-                    let hash_hex = prefix;
-                    let object_hex = rest;
+        for (line_index, line) in mapping_str.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
 
-                    if hash_hex.len() == N * 2 {
-                        let mut hash_bytes = Vec::new();
-                        for i in 0..N {
-                            if let Ok(byte) = u8::from_str_radix(&hash_hex[i * 2..i * 2 + 2], 16) {
-                                hash_bytes.push(byte);
-                            } else {
-                                break;
-                            }
-                        }
+            let line_number = line_index + 1;
+            let (prefix, rest) = line.split_once(':').ok_or_else(|| {
+                GitKvError::GitObjectError(format!("Malformed hash mapping on line {line_number}"))
+            })?;
 
-                        if hash_bytes.len() == N {
-                            if let Ok(object_id) = gix::ObjectId::from_hex(object_hex.as_bytes()) {
-                                let hash = ValueDigest::raw_hash(&hash_bytes);
-                                hash_mappings.insert(hash, object_id);
-                            }
-                        }
-                    }
+            if prefix == "key" {
+                // This is a simple key-value mapping from InMemory storage
+                is_simple_mapping = true;
+                let (key_hex, value_hex) = rest.split_once(':').ok_or_else(|| {
+                    GitKvError::GitObjectError(format!(
+                        "Malformed simple key mapping on line {line_number}"
+                    ))
+                })?;
+                let key = hex::decode(key_hex).map_err(|e| {
+                    GitKvError::GitObjectError(format!(
+                        "Invalid simple key hex on line {line_number}: {e}"
+                    ))
+                })?;
+                let value = hex::decode(value_hex).map_err(|e| {
+                    GitKvError::GitObjectError(format!(
+                        "Invalid simple value hex on line {line_number}: {e}"
+                    ))
+                })?;
+                key_values.insert(key, value);
+            } else {
+                // This is a hash mapping from Git storage
+                let hash_hex = prefix;
+                let object_hex = rest;
+
+                if hash_hex.len() != N * 2 {
+                    return Err(GitKvError::GitObjectError(format!(
+                        "Invalid prolly hash on line {line_number}: expected {} hex chars, got {}",
+                        N * 2,
+                        hash_hex.len()
+                    )));
                 }
+
+                let hash_bytes = hex::decode(hash_hex).map_err(|e| {
+                    GitKvError::GitObjectError(format!(
+                        "Invalid prolly hash on line {line_number}: {e}"
+                    ))
+                })?;
+                let object_id = gix::ObjectId::from_hex(object_hex.as_bytes()).map_err(|e| {
+                    GitKvError::GitObjectError(format!(
+                        "Invalid git object id on line {line_number}: {e}"
+                    ))
+                })?;
+                let hash = ValueDigest::raw_hash(&hash_bytes);
+                hash_mappings.insert(hash, object_id);
             }
         }
 

--- a/src/git/versioned_store/tests.rs
+++ b/src/git/versioned_store/tests.rs
@@ -269,6 +269,56 @@ mod tests {
     }
 
     #[test]
+    fn get_keys_at_ref_rejects_invalid_committed_hash_mapping_entry() {
+        let temp_dir = TempDir::new().unwrap();
+        gix::init(temp_dir.path()).unwrap();
+        let dataset_dir = temp_dir.path().join("dataset");
+        std::fs::create_dir_all(&dataset_dir).unwrap();
+        let _cwd = CwdGuard::set(&dataset_dir);
+
+        std::process::Command::new("git")
+            .args(["config", "user.name", "ProllyTree Test"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git config user.name");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "prollytree@example.test"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git config user.email");
+
+        let mut store = GitVersionedKvStore::<32>::init(&dataset_dir).unwrap();
+        store.insert(b"key".to_vec(), b"value".to_vec()).unwrap();
+        store.commit("valid mappings").unwrap();
+
+        let mapping_path = dataset_dir.join("prolly_hash_mappings");
+        let mut mappings = std::fs::read_to_string(&mapping_path).unwrap();
+        mappings.push_str("not-hex:also-not-a-git-object\n");
+        std::fs::write(&mapping_path, mappings).unwrap();
+
+        let add = std::process::Command::new("git")
+            .args(["add", "dataset/prolly_hash_mappings"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git add");
+        assert!(add.status.success(), "git add failed: {add:?}");
+        let commit = std::process::Command::new("git")
+            .args(["commit", "-m", "corrupt mappings"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("git commit");
+        assert!(commit.status.success(), "git commit failed: {commit:?}");
+
+        let err = store
+            .get_keys_at_ref("HEAD")
+            .expect_err("invalid committed mapping entries must fail");
+        assert!(
+            err.to_string().contains("Invalid prolly hash"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn test_basic_kv_operations() {
         let temp_dir = TempDir::new().unwrap();
         // Initialize git repository (regular, not bare)


### PR DESCRIPTION
# Bug #49: Versioned Reads Silently Ignored Malformed Hash Mappings

## Summary

`GitVersionedKvStore::get_keys_at_ref` reconstructed historical Git-backed trees from the
committed `prolly_hash_mappings` file. Its parser accepted malformed mapping rows by
falling through nested `if let` checks and skipping invalid entries.

## Impact

Historical reads could return a partial or stale key/value view when a committed
`prolly_hash_mappings` file was corrupt. That hid repository corruption from callers and
made audit/history operations look successful when the data needed to rebuild the tree
was invalid.

## Fix

`collect_keys_at_commit` now fails fast on malformed committed mapping rows:

- missing `:` delimiters,
- malformed simple `key:<hex>:<hex>` entries,
- prolly hashes with the wrong hex length,
- invalid prolly hash hex,
- invalid Git object IDs.

Blank lines remain ignored.

## Regression Coverage

The new regression test commits a valid tree, corrupts the committed
`dataset/prolly_hash_mappings` file in a later commit, then verifies that
`get_keys_at_ref("HEAD")` returns an error containing `Invalid prolly hash` instead of
returning the older key/value map.

## Verification

- RED: `CARGO_TARGET_DIR=/tmp/prollytree-bug49-target cargo test --features "git sql" get_keys_at_ref_rejects_invalid_committed_hash_mapping_entry -- --nocapture`
- GREEN: same focused test after the fix.
- Nearby regression: historical-read tests that rely on committed mapping files.
- Quality gates: `cargo fmt --all -- --check`, `git diff --check`, and shortcut-marker scan.
